### PR TITLE
Proposal to always invoke yarn, even on cache hit

### DIFF
--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -32,6 +32,6 @@ runs:
           ${{ runner.os }}-node-${{ inputs.node-version }}-yarn-
 
     - name: Install yarn dependencies
-      if: ${{ inputs.install-dependencies == 'true' && steps.yarn-cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.install-dependencies == 'true' }}
       run: yarn --prefer-offline --frozen-lockfile
       shell: bash


### PR DESCRIPTION
### Proposal

Always invoke `yarn install`, even if cache is present

### Why

When running `yarn install` or `npm install`. The `postinstall` and `preinstall` hooks are invoked in `package.json`. I would like to test out an experiment where we generate GraphQL Codegen using `postinstall` hook.

### Drawback

* Adds a sub-second delay due to running `yarn install` with cache present.