### PR TITLE
Allow to specify file for node version

### DIFF
--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -11,9 +11,8 @@ inputs:
     required: false
     type: string
   node_version_file:
-    default: ""
     description: File that specifies node version
-    required: false
+    required: true
     type: string
   personal_access_token:
     description: Personal access token generated for the repository

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -10,6 +10,11 @@ inputs:
     description: Run additional rake tasks when creating database, separate with spaces
     required: false
     type: string
+  node_version_file:
+    default: ""
+    description: File that specifies node version
+    required: false
+    type: string
   personal_access_token:
     description: Personal access token generated for the repository
     required: true
@@ -62,7 +67,7 @@ runs:
       with:
         cache: yarn
         cache-dependency-path: ${{ inputs.working_directory }}
-        node-version-file: ${{ inputs.working_directory }}/.tool-versions
+        node-version-file: ${{ inputs.working_directory }}/${{ inputs.node_version_file }}
 
     - name: Install yarn dependencies
       run: yarn --prefer-offline --frozen-lockfile


### PR DESCRIPTION
Since we use `.tool-versions` & `.nvmrc` this allows for use of either. Also, the setup-node action doesn't work well when inline comments are used within `.tool-versions`