### PR TITLE
Remove yarn cache in setup-repo

### DIFF
--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -64,7 +64,6 @@ runs:
     - name: Install Node for repo
       uses: actions/setup-node@v3
       with:
-        cache: yarn
         node-version-file: ${{ inputs.working_directory }}/${{ inputs.node_version_file }}
 
     - name: Install yarn dependencies

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -65,7 +65,6 @@ runs:
       uses: actions/setup-node@v3
       with:
         cache: yarn
-        cache-dependency-path: ${{ inputs.working_directory }}
         node-version-file: ${{ inputs.working_directory }}/${{ inputs.node_version_file }}
 
     - name: Install yarn dependencies


### PR DESCRIPTION
Caching yarn has little to no effect on runtime and will sometimes cause problems with builds, removing it seems like the best option