### PR TITLE
Use working directory to restore caches

### DIFF
--- a/precompile-assets/action.yml
+++ b/precompile-assets/action.yml
@@ -1,4 +1,11 @@
 name: "Precompile Assets"
+
+inputs:
+  working-directory:
+    description: "Working directory to restore/install"
+    default: ""
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -7,11 +14,12 @@ runs:
       id: assets-cache
       with:
         path: |
-          **/public/assets
-          **/public/vite-test
-        key: ${{ runner.os }}-precompiled-assets-${{ github.sha }}
+          ${{ inputs.working-directory == '' && './**' || inputs.working-directory }}/public/assets
+          ${{ inputs.working-directory == '' && './**' || inputs.working-directory }}/public/vite-test
+        key: ${{ runner.os }}-precompiled-assets-${{ github.sha }}-dir-${{ inputs.working-directory }}
 
     - name: Compile assets
       if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}
       run: NODE_ENV=development bundle exec rake assets:precompile
       shell: bash
+      working-directory: ${{ inputs.working-directory }}

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -9,6 +9,12 @@ inputs:
   install-dependencies:
     description: "Whether or not to install dependencies"
     default: true
+    required: false
+  working-directory:
+    description: "Working directory to restore/install"
+    default: ""
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -21,6 +27,7 @@ runs:
       id: yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Restore yarn cache, if exists
       uses: actions/cache@v3
@@ -28,18 +35,20 @@ runs:
       id: yarn-cache
       with:
         path: |
-          **/node_modules
+          ${{ inputs.working-directory == '' && './**' || inputs.working-directory }}/node_modules
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ inputs.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-node-${{ inputs.node-version }}-dir-${{ inputs.working-directory }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.working-directory == '' && './**' || inputs.working-directory)) }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ inputs.node-version }}-yarn-
+          ${{ runner.os }}-node-${{ inputs.node-version }}-dir-${{ inputs.working-directory }}-yarn-
 
     - name: Authenticate with private NPM package
       if: ${{ inputs.install-dependencies == 'true' && inputs.npm_access_token }}
       run: echo "//registry.npmjs.org/:_authToken=${{ inputs.npm_access_token }}" > ~/.npmrc
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Install yarn dependencies
       if: ${{ inputs.install-dependencies == 'true' && steps.yarn-cache.outputs.cache-hit != 'true' }}
       run: yarn --prefer-offline --frozen-lockfile
       shell: bash
+      working-directory: ${{ inputs.working-directory }}

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -78,7 +78,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
 
     - name: Install Node
-      uses: BuoySoftware/github-actions/setup-node@vo/node-wd
+      uses: BuoySoftware/github-actions/setup-node@main
       with:
         node-version: ${{ steps.repo_node_vers.outputs.v }}
         npm_access_token: ${{ inputs.npm_access_token }}
@@ -90,7 +90,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
 
     - name: Precompile test assets
-      uses: BuoySoftware/github-actions/precompile-assets@vo/node-wd
+      uses: BuoySoftware/github-actions/precompile-assets@main
       with:
         working-directory: ${{ inputs.working_directory }}
 

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -11,8 +11,9 @@ inputs:
     required: false
     type: string
   node_version_file:
-    description: File that specifies node version
-    required: true
+    default: ".tool-versions"
+    description: Node version file (.tool-versions, .nvmrc)
+    required: false
     type: string
   npm_access_token:
     description: Access token for downloading private npm packages from @buoysoftware
@@ -59,14 +60,6 @@ runs:
       run: sudo apt-get update && sudo apt-get install -y libvips
       shell: bash
 
-    - name: Install Java
-      if: endsWith(inputs.repo, 'BuoyRails')
-      uses: actions/setup-java@v3
-      with:
-        distribution: zulu
-        java-version: 11
-        architecture: x64
-
     - name: Set up environment variables for repo
       run: cp .env.sample .env
       shell: bash
@@ -78,39 +71,32 @@ runs:
         bundler-cache: true
         working-directory: ${{ inputs.working_directory }}
 
-    - name: Install Node for repo
-      uses: actions/setup-node@v3
-      with:
-        node-version-file: ${{ inputs.working_directory }}/${{ inputs.node_version_file }}
-
-    - name: Authenticate with private NPM package
-      if: ${{ inputs.npm_access_token }}
-      run: echo "//registry.npmjs.org/:_authToken=${{ inputs.npm_access_token }}" > ~/.npmrc
-      shell: bash
-
-    - name: Install yarn dependencies
-      run: yarn --prefer-offline --frozen-lockfile
+    - name: Get node version
+      id: repo_node_vers
+      run: echo "v=$(grep 'nodejs' ${{ inputs.node_version_file }} | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       shell: bash
       working-directory: ${{ inputs.working_directory }}
+
+    - name: Install Node
+      uses: BuoySoftware/github-actions/setup-node@vo/node-wd
+      with:
+        node-version: ${{ steps.repo_node_vers.outputs.v }}
+        npm_access_token: ${{ inputs.npm_access_token }}
+        working-directory: ${{ inputs.working_directory }}
 
     - name: bundle check for repo
       run: bundle check
       shell: bash
       working-directory: ${{ inputs.working_directory }}
 
-    - name: Compile assets for repo
-      run: NODE_ENV=development bundle exec rake assets:precompile
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
+    - name: Precompile test assets
+      uses: BuoySoftware/github-actions/precompile-assets@vo/node-wd
+      with:
+        working-directory: ${{ inputs.working_directory }}
 
     - name: Create, load and seed repo database
       env:
         DB_TEST_DATABASE: ${{ inputs.database_name }}
       run: bundle exec rake db:drop db:create db:schema:load ${{ inputs.extra_rake_tasks }}
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
-
-    - name: Enable caching
-      run: touch tmp/caching-dev.txt
       shell: bash
       working-directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
The automation repo (and the Infirmary e2e job) currently have nested repos which could cause issues with caching yarn and vite. 

This allows us to direct our caches to particular directories. The default is an empty string (which allows our current jobs to maintain the status quo)