### PR TITLE
Revert "Migrate to Github Packages"

### DIFF
--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -3,8 +3,8 @@ inputs:
   node-version:
     description: "Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0."
     required: true
-  github_npm_access_token:
-    description: "Access token for downloading private npm packages from Github Packages"
+  npm_access_token:
+    description: "Access token for downloading private npm packages from @buoysoftware"
     required: false
   install-dependencies:
     description: "Whether or not to install dependencies"
@@ -41,9 +41,9 @@ runs:
         restore-keys: |
           ${{ runner.os }}-node-${{ inputs.node-version }}-dir-${{ inputs.working-directory }}-yarn-
 
-    - name: Authenticate with Github Packages
-      if: ${{ inputs.install-dependencies == 'true' }}
-      run: echo "//npm.pkg.github.com/:_authToken=${{ inputs.github_npm_access_token }}" > ~/.npmrc && echo "@buoysoftware:registry=https://npm.pkg.github.com/" >> .npmrc
+    - name: Authenticate with private NPM package
+      if: ${{ inputs.install-dependencies == 'true' && inputs.npm_access_token }}
+      run: echo "//registry.npmjs.org/:_authToken=${{ inputs.npm_access_token }}" > ~/.npmrc
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -15,8 +15,8 @@ inputs:
     description: Node version file (.tool-versions, .nvmrc)
     required: false
     type: string
-  github_npm_access_token:
-    description: Access token for downloading private npm packages from Github Packages
+  npm_access_token:
+    description: Access token for downloading private npm packages from @buoysoftware
     required: false
     type: string
   personal_access_token:
@@ -81,7 +81,7 @@ runs:
       uses: BuoySoftware/github-actions/setup-node@main
       with:
         node-version: ${{ steps.repo_node_vers.outputs.v }}
-        github_npm_access_token: ${{ inputs.github_npm_access_token }}
+        npm_access_token: ${{ inputs.npm_access_token }}
         working-directory: ${{ inputs.working_directory }}
 
     - name: bundle check for repo


### PR DESCRIPTION
This reverts commit afa38e0ae0d146a5ded780c8b175bdc72ae2ad62.

Packages from the same scope cannot live in different registries, so we go back to the previous approach an use the NPM registry for all.