### PR TITLE
Create `tmp/pids` if folder doesn't exist

### DIFF
--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -103,3 +103,4 @@ runs:
           mkdir -p tmp/pids
         fi
       shell: bash
+      working-directory: ${{ inputs.working_directory }}

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -96,3 +96,10 @@ runs:
       run: bundle exec rake db:drop db:create db:schema:load ${{ inputs.extra_rake_tasks }}
       shell: bash
       working-directory: ${{ inputs.working_directory }}
+
+    - name: Add tmp/pids folder
+      run: |
+        if [ ! -d tmp/pids ]; then
+          mkdir -p tmp/pids
+        fi
+      shell: bash


### PR DESCRIPTION
Wharf was unable to start puma without this folder. Didn't run into this problem when setting up e2e runs for Buoy or Infirmary, but needed to add this in for Wharf. 