### PR TITLE
Use global GH_PACKAGES_TOKEN

### DIFF
--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -6,9 +6,6 @@ inputs:
   npm_access_token:
     description: "Access token for downloading private npm packages from @buoysoftware"
     required: false
-  github_npm_access_token:
-    description: "Access token for downloading private npm packages from @buoysoftware via Github Packages"
-    required: false
   install-dependencies:
     description: "Whether or not to install dependencies"
     default: true
@@ -51,8 +48,8 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Authenticate with Github Packages
-      if: ${{ inputs.install-dependencies == 'true' && inputs.github_npm_access_token }}
-      run: echo "//npm.pkg.github.com/:_authToken=${{ inputs.github_npm_access_token }}" > ~/.npmrc && echo "@buoysoftware:registry=https://npm.pkg.github.com/" >> .npmrc
+      if: ${{ inputs.install-dependencies == 'true' && inputs.github_npm_access_token == '' }}
+      run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" > ~/.npmrc && echo "@buoysoftware:registry=https://npm.pkg.github.com/" >> .npmrc
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 


### PR DESCRIPTION
I've set an org wide GH_PACKAGES_TOKEN that way we can use the "Install Node" action and it "just works" instead of having to manually pass in the token all the time.