### PR TITLE
Ability to pass in a git sha to the precompile assets cache key

### DIFF
--- a/precompile-assets/action.yml
+++ b/precompile-assets/action.yml
@@ -1,6 +1,11 @@
 name: "Precompile Assets"
 
 inputs:
+  github_sha:
+    default: ""
+    description: "Github sha to store in the cache key"
+    required: false
+    type: string
   working-directory:
     description: "Working directory to restore/install"
     default: ""
@@ -17,7 +22,7 @@ runs:
           ${{ inputs.working-directory == '' && './**' || inputs.working-directory }}/public/assets
           ${{ inputs.working-directory == '' && './**' || inputs.working-directory }}/public/vite-test
           ${{ inputs.working-directory == '' && './**' || inputs.working-directory }}/app/assets/builds
-        key: ${{ runner.os }}-precompiled-assets-${{ github.sha }}-dir-${{ inputs.working-directory }}
+        key: ${{ runner.os }}-precompiled-assets-${{ inputs.github_sha || github.sha }}-dir-${{ inputs.working-directory }}
 
     - name: Compile assets
       if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -57,6 +57,12 @@ runs:
         repository: ${{ inputs.repo }}
         token: ${{ inputs.personal_access_token }}
 
+    - name: Gather github sha
+      run: |
+        echo "repo_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+
     - name: Install Vips
       if: endsWith(inputs.repo, 'BuoyRails')
       run: sudo apt-get update && sudo apt-get install -y libvips
@@ -94,8 +100,9 @@ runs:
       working-directory: ${{ inputs.working_directory }}
 
     - name: Precompile test assets
-      uses: BuoySoftware/github-actions/precompile-assets@main
+      uses: BuoySoftware/github-actions/precompile-assets@vo/pre
       with:
+        github_sha: ${{ env.repo_sha }}
         working-directory: ${{ inputs.working_directory }}
 
     - name: Create, load and seed repo database

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -100,7 +100,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
 
     - name: Precompile test assets
-      uses: BuoySoftware/github-actions/precompile-assets@vo/pre
+      uses: BuoySoftware/github-actions/precompile-assets@main
       with:
         github_sha: ${{ env.repo_sha }}
         working-directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
`github.sha` will only point to what was checked out, we want the ability to point it to the sha we are actually caching against