### PR TITLE
Move database setup before Precompile test assets

### DIFF
--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -115,16 +115,16 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working_directory }}
 
+    - name: Create, load and seed repo database
+      run: bundle exec rake db:drop db:create db:schema:load ${{ inputs.extra_rake_tasks }}
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+
     - name: Precompile test assets
       uses: BuoySoftware/github-actions/precompile-assets@main
       with:
         github_sha: ${{ env.repo_sha }}
         working-directory: ${{ inputs.working_directory }}
-
-    - name: Create, load and seed repo database
-      run: bundle exec rake db:drop db:create db:schema:load ${{ inputs.extra_rake_tasks }}
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
 
     - name: Add tmp/pids folder
       run: |


### PR DESCRIPTION
A change was made that requires us to create the dstabase before precompiling test assets 