### PR TITLE
Remove replace_vars_with_lvh_host

### DIFF
--- a/setup-env/action.yml
+++ b/setup-env/action.yml
@@ -6,11 +6,6 @@ inputs:
     description: Environment variables to set
     required: false
     type: string
-  replace_vars_with_lvh_host:
-    default: ""
-    description: Space delimited list of environment variables to replace localhost with lvh.me
-    required: false
-    type: string
   working_directory:
     default: "."
     description: Desired working directory for the repository
@@ -25,12 +20,5 @@ runs:
       run: |
         # Store environment variables in a .env file
         printf '%s\n' "${{ inputs.env_vars }}" >> .env
-
-        # Use lvh.me as the host for specific environment variables
-        ARRAY=(${{ inputs.replace_vars_with_lvh_host }})
-        for i in "${ARRAY[@]}"
-        do
-          sed -r -i -E "s/($i=.*)localhost/\1lvh.me/" .env
-        done
       shell: bash
       working-directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
No longer needed
 
 **PR Summary by Typo**
------------

 **Summary:**
This pull request removes an input and related code for localhost replacement, updates a working directory label.

**Key Points:**

1. Removes "replace\_vars\_with\_lvh\_host" input and related bash script.
2. Updates "working directory" input with a more descriptive label. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>