### PR TITLE
Remove replace_vars_with_lvh_host from setup-repo

### DIFF
--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -29,11 +29,6 @@ inputs:
     description: The branch, tag or SHA to checkout, ie `v1.2.0`
     required: false
     type: string
-  replace_vars_with_lvh_host:
-    default: ""
-    description: Space delimited list of environment variables to replace localhost with lvh.me
-    required: false
-    type: string
   repo:
     description: Full repository name (Org/Repo)
     required: true
@@ -88,7 +83,6 @@ runs:
       uses: BuoySoftware/github-actions/setup-env@main
       with:
         env_vars: ${{ inputs.env_vars }}
-        replace_vars_with_lvh_host: ${{ inputs.replace_vars_with_lvh_host }}
         working_directory: ${{ inputs.working_directory }}
 
     - name: Install Ruby for repo


### PR DESCRIPTION
Follow up to https://github.com/BuoySoftware/github-actions/pull/40, and will remove warning messages in CI runs