### PR TITLE
Upgrade actions from v3 to v4

### DIFF
--- a/deploy-image-v2/action.yml
+++ b/deploy-image-v2/action.yml
@@ -41,7 +41,7 @@ runs:
 
   steps:
     - name: Checkout Manifests Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: ${{ inputs.working_directory }}
         repository: ${{ inputs.manifests_repository }}

--- a/precompile-assets/action.yml
+++ b/precompile-assets/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Restore precompiled assets cache, if exists
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: assets-cache
       with:
         path: |

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
 
@@ -33,7 +33,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Restore yarn cache, if exists
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: ${{ inputs.install-dependencies == 'true' }}
       id: yarn-cache
       with:


### PR DESCRIPTION
Seeing alot of deprecation warnings in jobs. Updating from v3 to v4 to remove the warnings.
<img width="1348" alt="Screenshot 2024-11-14 at 4 18 47 PM" src="https://github.com/user-attachments/assets/3414ebf5-fb0f-4e50-afbe-7bb0641cb9e8">

Checked all of the repo .tool-versions using this search `path:**/.tool-versions`.

Only a few repos are using a node version under 20, the only one using the shared actions is the public repo https://github.com/BuoySoftware/anchor-ui. This is legacy code and no longer in use.

Also ensured all of the same inputs are still in use for setup-node, cache and checkout