### PR TITLE
Update build-image to support git tags

### DIFF
--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -16,6 +16,10 @@ inputs:
   build_args:
     description: Additional docker build args
     type: string
+  slack_webhook_url:
+    description: Slack webhook URL for notifications
+    required: false
+    type: string
 
 outputs:
   registry:
@@ -23,7 +27,7 @@ outputs:
     value: ${{ steps.login-ecr.outputs.registry }}
   short_sha_tag: 
     description: "Short SHA tag assigned to the image"
-    value: sha-${{ steps.current-git-sha.outputs.short }}
+    value: ${{ steps.current-git-details.outputs.short }}
 
 runs:
   using: "composite"
@@ -32,12 +36,18 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Read current git sha details
-      id: current-git-sha
+    - name: Read current git details
+      id: current-git-details
       shell: bash
       run: |
-        echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-        echo "long=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        echo "short=sha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "long=sha-$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+        if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          echo "tag=tag-${{ github.ref_name }}" >> $GITHUB_OUTPUT
+        else
+          echo "tag=" >> $GITHUB_OUTPUT
+        fi
 
     - name: Configure Amazon ECR Credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -50,21 +60,70 @@ runs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Build, tag, and push docker image to Amazon ECR
+    - name: Check if the image already exists
+      id: check-image-exists
       shell: bash
       env:
         REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         REPOSITORY: ${{ inputs.ecr_repository }}
-        SHORT_SHA_TAG: sha-${{ steps.current-git-sha.outputs.short }}
-        LONG_SHA_TAG: sha-${{ steps.current-git-sha.outputs.long }}
+        SHORT_SHA_TAG: ${{ steps.current-git-details.outputs.short }}
+        REF_TAG: ${{ steps.current-git-details.outputs.tag }}
+      run: |
+        REF_IMAGE_EXISTS=$(docker manifest inspect $REGISTRY/$REPOSITORY:$REF_TAG > /dev/null 2>&1 && echo yes || echo no)
+        SHORT_IMAGE_EXISTS=$(docker manifest inspect $REGISTRY/$REPOSITORY:$SHORT_SHA_TAG > /dev/null 2>&1 && echo yes || echo no)
+
+        if [[ "$REF_IMAGE_EXISTS" == "yes" && "$SHORT_IMAGE_EXISTS" == "yes" ]]; then
+          echo "Image already exists, skipping build step"
+          echo "image_exists=true" >> $GITHUB_OUTPUT
+        elif [[ -n "$REF_TAG" && "$REF_IMAGE_EXISTS" == "no" && "$SHORT_IMAGE_EXISTS" == "yes" ]]; then
+          echo "Ref tag is not empty, and ref image doesn't exist, but short image does. Pulling short image and tagging it with ref tag."
+          docker pull $REGISTRY/$REPOSITORY:$SHORT_SHA_TAG
+          docker tag $REGISTRY/$REPOSITORY:$SHORT_SHA_TAG $REGISTRY/$REPOSITORY:$REF_TAG
+          docker push $REGISTRY/$REPOSITORY:$REF_TAG
+          echo "Skipping build step"
+          echo "image_exists=true" >> $GITHUB_OUTPUT
+        elif [[ -z "$REF_TAG" && "$REF_IMAGE_EXISTS" == "no" && "$SHORT_IMAGE_EXISTS" == "yes" ]]; then
+          echo "Ref tag is empty, and ref image doesn't exist, but short image does. Skipping build step"
+          echo "image_exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "Image not found, proceeding with build step"
+          echo "image_exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Build, tag, and push docker image to Amazon ECR
+      if: steps.check-image-exists.outputs.image_exists == 'false'
+      shell: bash
+      env:
+        REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        REPOSITORY: ${{ inputs.ecr_repository }}
+        SHORT_SHA_TAG: ${{ steps.current-git-details.outputs.short }}
+        LONG_SHA_TAG: ${{ steps.current-git-details.outputs.long }}
+        REF_TAG: ${{ steps.current-git-details.outputs.tag }}
         BUILD_ARGS: ${{ inputs.build_args }}
       run: |
-        echo "Checking if image $REGISTRY/$REPOSITORY:$SHORT_SHA_TAG already exist..."
-        IMAGE_EXISTS=$(docker manifest inspect $REGISTRY/$REPOSITORY:$SHORT_SHA_TAG > /dev/null 2>&1 && echo yes || echo no)
-        if [[  $IMAGE_EXISTS == "yes"  ]]; then
-          echo "Image was found, skipping build."
-        else
-          echo "Image not found, building..."
-          docker build . -t $REGISTRY/$REPOSITORY:$SHORT_SHA_TAG -t $REGISTRY/$REPOSITORY:$LONG_SHA_TAG $BUILD_ARGS
+          TAGS="-t $REGISTRY/$REPOSITORY:$SHORT_SHA_TAG -t $REGISTRY/$REPOSITORY:$LONG_SHA_TAG"
+          if [ -n "${{ steps.current-git-details.outputs.tag }}" ]; then
+            TAGS="$TAGS -t $REGISTRY/$REPOSITORY:$REF_TAG"
+          fi
+
+          docker build . $TAGS $BUILD_ARGS
           docker push --all-tags $REGISTRY/$REPOSITORY
-        fi
+
+    - name: Notify Slack on failure
+      if: failure() && inputs.slack_webhook_url != ''
+      uses: 8398a7/action-slack@v3
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
+        AS_REF: ${{ github.ref }}
+        AS_AUTHOR: ${{ github.actor }}
+      with:
+        status: custom
+        fields: workflow,job,commit,repo,ref,author,took
+        custom_payload: |
+          {
+            "attachments": [{
+              "color": "danger",
+              "mrkdwn_in": ["text"],
+              "text": ":x: *Docker build failed*\n*Ref:* ${{ env.AS_REF }}\n*Author:* ${{ env.AS_AUTHOR }}\n\nPlease check the CI job logs for details: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+            }]
+          }

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -106,7 +106,7 @@ runs:
             TAGS="$TAGS -t $REGISTRY/$REPOSITORY:$REF_TAG"
           fi
 
-          docker build . $TAGS $BUILD_ARGS
+          docker build . $TAGS $BUILD_ARGS --build-arg CURR_GIT_SHA=$LONG_SHA_TAG
           docker push --all-tags $REGISTRY/$REPOSITORY
 
     - name: Notify Slack on failure

--- a/deploy-image-v2/action.yml
+++ b/deploy-image-v2/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: Personal access token generated for the manifests repository
     required: true
     type: string
+  slack_webhook_url:
+    description: Slack webhook URL for notifications
+    required: false
+    type: string
   working_directory:
     default: "."
     description: Desired working directory for the manifests repository
@@ -77,3 +81,22 @@ runs:
         git commit -am "Update deployment image tag for ${{ inputs.application }}-${{ inputs.environment }} to ${{ inputs.image_tag }} [skip ci]"
         git pull --rebase --autostash
         git push
+
+    - name: Notify Slack on failure
+      if: failure() && inputs.slack_webhook_url != ''
+      uses: 8398a7/action-slack@v3
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
+        AS_REF: ${{ github.ref }}
+        AS_AUTHOR: ${{ github.actor }}
+      with:
+        status: custom
+        fields: workflow,job,commit,repo,ref,author,took
+        custom_payload: |
+          {
+            "attachments": [{
+              "color": "danger",
+              "mrkdwn_in": ["text"],
+              "text": ":x: *Image deployment failed*\n*Ref:* ${{ env.AS_REF }}\n*Author:* ${{ env.AS_AUTHOR }}\n\nPlease check the CI job logs for details: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+            }]
+          }


### PR DESCRIPTION
Since the ECR tags are immutable, we need to be careful when we add a git tag. This will go through the logic:
- If the ref tag image and short sha image exist, skip the build https://github.com/BuoySoftware/Wharf/actions/runs/14912926689/job/41891492676 (ignore the deployment failure as it's unrelated)
- If a ref tag exists, ref tag image does not exist, but a short sha image exists -> pull down the docker image and tag it with the ref tag https://github.com/BuoySoftware/Wharf/actions/runs/14912822701/job/41891146222
- If a ref tag does not exist, ref tag image does not exist, but a short sha image exists -> skip the build  https://github.com/BuoySoftware/Wharf/actions/runs/14912882481/job/41891759784 (ignore the deployment failure as it's unrelated)
- Anything else, build https://github.com/BuoySoftware/Wharf/actions/runs/14912682255/job/41890667745

Once we build, if there is a ref tag, tag the new image with the ref tag. Otherwise only tag it with a short and long sha. 
Also, add a slack notification to the action to emit that something has gone wrong during build or deploy. 

ECR tag example (redacted) sha-short, tag-vinny-test, sha-long