### PR TITLE
Prevent failure without changes to commit

### DIFF
--- a/deploy-image-v2/action.yml
+++ b/deploy-image-v2/action.yml
@@ -78,9 +78,13 @@ runs:
       run: |
         git config --global user.name "buoysoftware-bot"
         git config --global user.email "buoysoftware-bot@users.noreply.github.com"
-        git commit -am "Update deployment image tag for ${{ inputs.application }}-${{ inputs.environment }} to ${{ inputs.image_tag }} [skip ci]"
-        git pull --rebase --autostash
-        git push
+        if ! git diff --cached --quiet; then
+          git commit -am "Update deployment image tag for ${{ inputs.application }}-${{ inputs.environment }} to ${{ inputs.image_tag }} [skip ci]"
+          git pull --rebase --autostash
+          git push
+        else
+          echo "No changes to commit."
+        fi
 
     - name: Notify Slack on failure
       if: failure() && inputs.slack_webhook_url != ''


### PR DESCRIPTION
We see many Docker failures each day caused by retries after a successful run. The action always expects something to commit. Prevent this by checking for changes first.

After
https://buoy-software.slack.com/archives/C01H937Q64R/p1751302738277489.