### PR TITLE
Make link-jira-ticket ticket ids case insensitive

### DIFF
--- a/link-jira-ticket/action.yml
+++ b/link-jira-ticket/action.yml
@@ -28,7 +28,7 @@ runs:
           # Trim whitespace from pattern
           pattern=$(echo "$pattern" | xargs)
           if [ -n "$pattern" ]; then
-            extracted=$(echo '${{ github.head_ref }}' | grep -oE "$pattern")
+            extracted=$(echo '${{ github.head_ref }}' | grep -oiE "$pattern")
             if [ -n "$extracted" ]; then
               ticket_id="$extracted"
               break


### PR DESCRIPTION
what it says on the tin. Allow jira ticket IDs to be whatever case they want.
DXD-30, dxd-30, DxD-30