### PR TITLE
(setup-node) detect yarn berry by yarnrc.yml presence

### DIFF
--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -53,20 +53,32 @@ runs:
       with:
         node-version: ${{ steps.find-node-version.outputs.v || inputs.node-version }}
 
+    - name: Detect Yarn Berry
+      id: detect-yarn-berry
+      run: |
+        dir="${{ inputs.working-directory }}"
+        dir="${dir:-.}"
+        if [ "${{ inputs.enable-corepack }}" == "true" ] || [ -f "$dir/.yarnrc.yml" ]; then
+          echo "is_berry=true" >> $GITHUB_OUTPUT
+        else
+          echo "is_berry=false" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
     - name: Enable corepack
-      if: ${{ inputs.enable-corepack == 'true' }}
+      if: ${{ steps.detect-yarn-berry.outputs.is_berry == 'true' }}
       run: corepack enable
       shell: bash
 
     - name: Get yarn cache directory path (Yarn 1.x)
-      if: ${{ inputs.install-dependencies == 'true' && inputs.enable-corepack != 'true' }}
+      if: ${{ inputs.install-dependencies == 'true' && steps.detect-yarn-berry.outputs.is_berry != 'true' }}
       id: yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
     - name: Get yarn cache directory path (Yarn Berry)
-      if: ${{ inputs.install-dependencies == 'true' && inputs.enable-corepack == 'true' }}
+      if: ${{ inputs.install-dependencies == 'true' && steps.detect-yarn-berry.outputs.is_berry == 'true' }}
       id: yarn-berry-cache-dir-path
       run: echo "dir=$(yarn config get cacheFolder 2>/dev/null | tail -n1)" >> $GITHUB_OUTPUT
       shell: bash
@@ -97,13 +109,13 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Install yarn dependencies (Yarn 1.x)
-      if: ${{ inputs.install-dependencies == 'true' && steps.yarn-cache.outputs.cache-hit != 'true' && inputs.enable-corepack != 'true' }}
+      if: ${{ inputs.install-dependencies == 'true' && steps.yarn-cache.outputs.cache-hit != 'true' && steps.detect-yarn-berry.outputs.is_berry != 'true' }}
       run: yarn --prefer-offline --frozen-lockfile --ignore-scripts
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
     - name: Install yarn dependencies (Yarn Berry)
-      if: ${{ inputs.install-dependencies == 'true' && inputs.enable-corepack == 'true' }}
+      if: ${{ inputs.install-dependencies == 'true' && steps.detect-yarn-berry.outputs.is_berry == 'true' }}
       run: yarn install --immutable
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -58,8 +58,10 @@ runs:
       run: |
         dir="${{ inputs.working-directory }}"
         if [ "${{ inputs.enable-corepack }}" == "true" ] || [ -f "$dir/.yarnrc.yml" ]; then
+          echo "Yarn Berry detected"
           echo "is_berry=true" >> $GITHUB_OUTPUT
         else
+          echo "Yarn Classic detected"
           echo "is_berry=false" >> $GITHUB_OUTPUT
         fi
       shell: bash

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -57,7 +57,6 @@ runs:
       id: detect-yarn-berry
       run: |
         dir="${{ inputs.working-directory }}"
-        dir="${dir:-.}"
         if [ "${{ inputs.enable-corepack }}" == "true" ] || [ -f "$dir/.yarnrc.yml" ]; then
           echo "is_berry=true" >> $GITHUB_OUTPUT
         else

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -1,4 +1,5 @@
 name: Setup repo
+description: "Setup a repo for testing"
 
 inputs:
   env_vars:
@@ -75,7 +76,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
 
     - name: Install Node
-      uses: BuoySoftware/github-actions/setup-node@vo/detect-yarn-berry
+      uses: BuoySoftware/github-actions/setup-node@main
       with:
         node-version: ${{ steps.repo_node_vers.outputs.v }}
         github_packages_token: ${{ inputs.github_packages_token }}

--- a/setup-repo/action.yml
+++ b/setup-repo/action.yml
@@ -75,7 +75,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
 
     - name: Install Node
-      uses: BuoySoftware/github-actions/setup-node@main
+      uses: BuoySoftware/github-actions/setup-node@vo/detect-yarn-berry
       with:
         node-version: ${{ steps.repo_node_vers.outputs.v }}
         github_packages_token: ${{ inputs.github_packages_token }}


### PR DESCRIPTION
yarnrc.yml is unique to yarn berry so we can detect if it's yarn berry with the presence of it. In a follow up I can remove the enable-corepack input