### PR TITLE
Drop yarn global cache from setup-node

### DIFF
--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -71,28 +71,12 @@ runs:
       run: corepack enable
       shell: bash
 
-    - name: Get yarn cache directory path (Yarn 1.x)
-      if: ${{ inputs.install-dependencies == 'true' && steps.detect-yarn-berry.outputs.is_berry != 'true' }}
-      id: yarn-cache-dir-path
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-
-    - name: Get yarn cache directory path (Yarn Berry)
-      if: ${{ inputs.install-dependencies == 'true' && steps.detect-yarn-berry.outputs.is_berry == 'true' }}
-      id: yarn-berry-cache-dir-path
-      run: echo "dir=$(yarn config get cacheFolder 2>/dev/null | tail -n1)" >> $GITHUB_OUTPUT
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-
-    - name: Restore yarn cache, if exists
+    - name: Restore node_modules cache
       uses: actions/cache@v3
       if: ${{ inputs.install-dependencies == 'true' }}
       id: yarn-cache
       with:
-        path: |
-          ${{ inputs.working-directory == '' && './**' || inputs.working-directory }}/node_modules
-          ${{ steps.yarn-cache-dir-path.outputs.dir || steps.yarn-berry-cache-dir-path.outputs.dir }}
+        path: ${{ inputs.working-directory == '' && './**' || inputs.working-directory }}/node_modules
         key: ${{ runner.os }}-node-${{ steps.find-node-version.outputs.v || inputs.node-version }}-dir-${{ inputs.working-directory }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.working-directory == '' && './**' || inputs.working-directory)) }}
         restore-keys: |
           ${{ runner.os }}-node-${{ steps.find-node-version.outputs.v || inputs.node-version }}-dir-${{ inputs.working-directory }}-yarn-
@@ -111,7 +95,7 @@ runs:
 
     - name: Install yarn dependencies (Yarn 1.x)
       if: ${{ inputs.install-dependencies == 'true' && steps.yarn-cache.outputs.cache-hit != 'true' && steps.detect-yarn-berry.outputs.is_berry != 'true' }}
-      run: yarn --prefer-offline --frozen-lockfile --ignore-scripts
+      run: yarn --frozen-lockfile --ignore-scripts
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 


### PR DESCRIPTION
## Summary

- Removes the yarn global cache directory (`~/.cache/yarn/v6`) from the `setup-node` cache
- Cache now stores only `node_modules` (~200MB vs ~2.4GB previously)
- Drops the two steps that resolved the yarn cache directory path, since they're no longer needed
- Removes `--prefer-offline` from the Yarn 1.x install command since there's no local mirror to prefer

## Why

The combined `node_modules` + yarn global cache archive was ~2.4GB (compressed). This was causing intermittent runner timeouts/shutdowns during cache extraction on CI, failing jobs before any tests ran.

The yarn global cache is a local npm mirror used to speed up installs when `yarn.lock` changes. Since `node_modules` itself is cached with the same key, the yarn global cache only helps on cache misses (lockfile changes) — a rare event. For a small dependency tree, downloading from npm on a cache miss takes ~60-90s, which is faster than downloading a 2.4GB archive.

## Impact

- **Cache hit (common case):** 12× faster restore (~200MB vs ~2.4GB)
- **Cache miss (lockfile changes):** ~60-90s slower install (downloads from npm instead of local mirror)
- Eliminates runner timeout failures caused by the oversized cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)