### PR TITLE
Bump deprecated Node 20 actions to Node 24 majors

### DIFF
--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -52,7 +52,7 @@ runs:
       shell: bash
 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true

--- a/deploy-image-v2/action.yml
+++ b/deploy-image-v2/action.yml
@@ -45,7 +45,7 @@ runs:
 
   steps:
     - name: Checkout Manifests Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         path: ${{ inputs.working_directory }}
         repository: ${{ inputs.manifests_repository }}

--- a/deploy-image/action.yml
+++ b/deploy-image/action.yml
@@ -37,7 +37,7 @@ runs:
 
   steps:
     - name: Checkout Manifests Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         path: ${{ inputs.working_directory }}
         repository: ${{ inputs.manifests_repository }}

--- a/precompile-assets/action.yml
+++ b/precompile-assets/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Restore precompiled assets cache, if exists
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       id: assets-cache
       with:
         path: |

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -49,7 +49,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ steps.find-node-version.outputs.v || inputs.node-version }}
 
@@ -72,7 +72,7 @@ runs:
       shell: bash
 
     - name: Restore node_modules cache
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       if: ${{ inputs.install-dependencies == 'true' }}
       id: yarn-cache
       with:


### PR DESCRIPTION
## Summary

GitHub Actions workflows using these deprecated versions are emitting warnings and will be forced to Node 24 on **June 2, 2026**; Node 20 is removed from runners **September 16, 2026** ([announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

Bumps each Node 20 action to its current major on Node 24:

- `actions/checkout` v3/v4 → **v6**
- `actions/cache` v3 → **v5**
- `actions/setup-node` v3 → **v6**

## Changes

| File | Action | Before | After |
|---|---|---|---|
| `checkout/action.yml` | checkout | v4 | v6 |
| `deploy-image/action.yml` | checkout | v3 | v6 |
| `deploy-image-v2/action.yml` | checkout | v3 | v6 |
| `precompile-assets/action.yml` | cache | v3 | v5 |
| `setup-node/action.yml` | setup-node | v3 | v6 |
| `setup-node/action.yml` | cache | v3 | v5 |

Left alone intentionally:
- `install-playwright-browsers/action.yml` — already `cache@v4`
- `generate-structure-sql/action.yml` — already `upload-artifact@v4`

Both of the v4s above still run on Node 20 and will flip to Node 24 at the June 2026 deadline, but the deprecation warning flagged the v3s, so this PR is scoped to that.

## Test plan

- [ ] CI passes on this branch
- [ ] Consumer workflows in BuoyRails / Wharf continue to run green against `@main`