### PR TITLE
Don't fail the trivy job when vulns found

### DIFF
--- a/trivy/action.yml
+++ b/trivy/action.yml
@@ -3,7 +3,7 @@ description: "Run an Aqua Trivy scan via a SHA-pinned upstream action"
 
 inputs:
   exit-code:
-    default: "1"
+    default: "0"
     description: Exit code when vulnerabilities are found (e.g. "1" to fail the job)
     required: false
     type: string


### PR DESCRIPTION
The failure is just noise versus an actual problem, we review the github summary for any vuln problems 