### PR TITLE
bundle-audit action to replace abandoned community action

### DIFF
--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -1,0 +1,65 @@
+name: Bundler audit
+description: "Scan Gemfile.lock for vulnerable gem dependencies with bundler-audit"
+
+inputs:
+  gemfile-lock:
+    default: ""
+    description: Path to a specific Gemfile.lock (relative to working-directory)
+    required: false
+    type: string
+  ignore:
+    default: ""
+    description: Space-separated advisory IDs to ignore (e.g. "CVE-2021-1234 GHSA-xxxx")
+    required: false
+    type: string
+  update:
+    default: "true"
+    description: Update the ruby-advisory-db before checking
+    required: false
+    type: string
+  version:
+    default: ""
+    description: bundler-audit gem version to install (defaults to latest)
+    required: false
+    type: string
+  working-directory:
+    default: "."
+    description: Directory containing the Gemfile.lock to audit
+    required: false
+    type: string
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Install bundler-audit
+      shell: bash
+      env:
+        BUNDLER_AUDIT_VERSION: ${{ inputs.version }}
+      run: |
+        if [[ -n "$BUNDLER_AUDIT_VERSION" ]]; then
+          gem install bundler-audit --version "$BUNDLER_AUDIT_VERSION" --no-document
+        else
+          gem install bundler-audit --no-document
+        fi
+
+    - name: Run bundler-audit
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        BUNDLER_AUDIT_GEMFILE_LOCK: ${{ inputs.gemfile-lock }}
+        BUNDLER_AUDIT_IGNORE: ${{ inputs.ignore }}
+        BUNDLER_AUDIT_UPDATE: ${{ inputs.update }}
+      run: |
+        args=(check)
+        if [[ "$BUNDLER_AUDIT_UPDATE" == "true" ]]; then
+          args+=(--update)
+        fi
+        if [[ -n "$BUNDLER_AUDIT_GEMFILE_LOCK" ]]; then
+          args+=(--gemfile-lock "$BUNDLER_AUDIT_GEMFILE_LOCK")
+        fi
+        if [[ -n "$BUNDLER_AUDIT_IGNORE" ]]; then
+          # Intentional word-splitting: ignore is a space-separated list of IDs
+          args+=(--ignore $BUNDLER_AUDIT_IGNORE)
+        fi
+        bundle-audit "${args[@]}"

--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -59,7 +59,9 @@ runs:
           args+=(--gemfile-lock "$BUNDLER_AUDIT_GEMFILE_LOCK")
         fi
         if [[ -n "$BUNDLER_AUDIT_IGNORE" ]]; then
-          # Intentional word-splitting: ignore is a space-separated list of IDs
-          args+=(--ignore $BUNDLER_AUDIT_IGNORE)
+          # Split the space-separated list of advisory IDs into array elements.
+          # read -ra splits on whitespace without glob expansion.
+          read -ra ignore_ids <<< "$BUNDLER_AUDIT_IGNORE"
+          args+=(--ignore "${ignore_ids[@]}")
         fi
         bundle-audit "${args[@]}"


### PR DESCRIPTION
We have an issue with our current bundle audit GH action as reported in https://github.com/BuoySoftware/InfirmaryEngine/pull/344, https://github.com/BuoySoftware/Infirmary/pull/1927, and ever further back in https://github.com/BuoySoftware/Infirmary/pull/290.

The GH action https://github.com/tomferreira/action-bundler-audit we are using is abandoned. Not updated in 4 years and has multiple PRs asking for an update to fix this issue we are encountering again.

What we were using is really just a wrapper for the bundle-audit gem that is written by rubysec and was parsing the output and doing a reivewdog comment/annotions on each gem from the bundle-audit findings.

This should not find things often so I don't think we need the convenience of reivewdog and can easily check the GH action output during any failures, similar to RSpec and other jobs.

----

Dependabot ultimately catching things, bundle-audit and Dependabot come from different advisory DBs (increasing our coverage). Also running bundle-audit can catch things immediately, before being introduced/merged to main, whereas Dependabot only catches things in main when it runs at different times (not always immediately). So they aren't exactly the same or completely redundant.

This bundle-audit also flags insecure gem sources (like a source over http instead of https), which Dependabot doesn't check at all.