### PR TITLE
feat: add dispatch-datahub-schema-ingest composite action

### DIFF
--- a/dispatch-datahub-schema-ingest/action.yml
+++ b/dispatch-datahub-schema-ingest/action.yml
@@ -1,0 +1,53 @@
+name: Dispatch DataHub schema ingest
+description: |
+  Fire a repository_dispatch event at the repository that owns the DataHub
+  ingest workflow, so it can download this app's structure.sql release asset,
+  parse it, and ingest the Postgres schema into DataHub.
+
+  Call this after the structure.sql asset has been uploaded to the GitHub
+  Release (i.e. on a tag push). The event type is pg-schema-release and the
+  client payload carries app, version, and github_repo. The receiving workflow
+  is expected to validate all three.
+
+inputs:
+  app:
+    description: "Application name to ingest the schema under in DataHub"
+    required: true
+  target_repo:
+    description: "owner/repo hosting the workflow that consumes the dispatch"
+    required: true
+  token:
+    description: "Token with permission to POST repository_dispatch on the target repo"
+    required: true
+  version:
+    description: "Release tag to ingest. Defaults to the pushed tag (github.ref_name)."
+    default: ""
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Dispatch pg-schema-release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        APP: ${{ inputs.app }}
+        VERSION: ${{ inputs.version }}
+        SOURCE_REPO: ${{ github.repository }}
+        TARGET_REPO: ${{ inputs.target_repo }}
+      run: |
+        set -euo pipefail
+        VERSION="${VERSION:-$GITHUB_REF_NAME}"
+        if [ -z "${APP}" ] || [ -z "${VERSION}" ] || [ -z "${TARGET_REPO}" ]; then
+          echo "::error::app, target_repo, and version are required"
+          exit 1
+        fi
+        curl -fsSL -X POST \
+          -H "Authorization: Bearer ${GH_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/repos/${TARGET_REPO}/dispatches" \
+          -d "$(jq -n \
+            --arg app "${APP}" \
+            --arg version "${VERSION}" \
+            --arg repo "${SOURCE_REPO}" \
+            '{event_type: "pg-schema-release", client_payload: {app: $app, version: $version, github_repo: $repo}}')"


### PR DESCRIPTION
## Summary

Add a shared composite action, `dispatch-datahub-schema-ingest`, that fires a `repository_dispatch` (`pg-schema-release`) at a target repository after an app uploads its `structure.sql` release asset on a `v*` tag. The receiving repository downloads the asset, parses it, and ingests the Postgres schema into DataHub. Part of DATA-887.

## Changes

- `dispatch-datahub-schema-ingest/action.yml`: composite action with required inputs `app`, `target_repo`, and `token`, plus optional `version` (defaults to the pushed tag via `GITHUB_REF_NAME`). It derives `github_repo` from `github.repository`, so callers never pass their own repo name.

## Why a shared action

The dispatch step was otherwise copy-pasted identically into each app repo's `structure-sql.yml`, differing only by app name. Centralizing it here dedupes that step and matches the existing `generate-structure-sql` action pattern.

## This repository is public

The action carries no organization-specific values. `target_repo` is a required input rather than a default, so the receiving repository, app names, and DataHub host all stay in the private caller workflows.

Composite actions do not enforce `required: true` at runtime, so the step checks `target_repo` for emptiness. Without that check, a caller omitting the input would POST to `api.github.com/repos//dispatches` instead of failing loudly.

## Out of scope

- The ingest workflow that receives the dispatch. It already lives on `main` in the receiving repository.
- Ingesting to fabrics other than DEV on tag push (DEV only for v1).
- Pre-existing organization-specific defaults in other actions here (`deploy-image`, `deploy-image-v2`, `setup-node`). Worth a follow-up, but not part of this change.

## Consumer impact

`target_repo` has no default, so any caller must pass it. The first consumer workflow is updated alongside this PR.

## Testing

### Prerequisites

- A consumer workflow referencing the action and passing `app`, `token`, and `target_repo`. Until this merges to `main`, reference the branch ref: `dispatch-datahub-schema-ingest@DATA-887/dispatch-datahub-schema-ingest`.
- The receiving repository's ingest workflow already accepts `repository_dispatch` with type `pg-schema-release`.

### Human review

- [ ] Read `dispatch-datahub-schema-ingest/action.yml`. Inputs match the payload the receiving workflow validates: `event_type: pg-schema-release`, `client_payload: {app, version, github_repo}`.
- [ ] Confirm nothing organization-specific remains in the action: no repo names, app names, hostnames, or account identifiers.
- [ ] Push a `v*` tag from a consumer repo and confirm the DataHub dataset for that app shows the schema from the release asset. An end-to-end run was verified on an earlier revision of this branch; re-verify after the `target_repo` change.

### AI / Automation

- [x] `yaml.safe_load` of `dispatch-datahub-schema-ingest/action.yml` succeeds, and the parsed inputs are `app`, `target_repo`, `token`, `version` with the first three required. Note: `actionlint` treats a composite `action.yml` as a workflow, so it is not applicable here.
- [x] The embedded step script passes `bash -n`.
- [x] Branch is up to date with `main` (ahead by 1, behind by 0).

Made in tandem with Cursor
