### PR TITLE
Bump Node 20 actions to Node 24 majors in build-image and deploy actions

### DIFF
--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -43,7 +43,7 @@ runs:
 
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
 
     - name: Read current git details
       id: current-git-details
@@ -79,7 +79,7 @@ runs:
         echo "Ref Tag: $tag" >> $GITHUB_STEP_SUMMARY
 
     - name: Configure Amazon ECR Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
@@ -87,7 +87,7 @@ runs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Check if the image already exists
       id: check-image-exists

--- a/deploy-image-v2/action.yml
+++ b/deploy-image-v2/action.yml
@@ -52,7 +52,7 @@ runs:
         token: ${{ inputs.personal_access_token }}
 
     - name: Set up Kustomize
-      uses: imranismail/setup-kustomize@v2
+      uses: imranismail/setup-kustomize@v3
 
     - name: "Update Deployment Image Tag"
       shell: bash

--- a/deploy-image/action.yml
+++ b/deploy-image/action.yml
@@ -44,7 +44,7 @@ runs:
         token: ${{ inputs.personal_access_token }}
 
     - name: Set up Kustomize
-      uses: imranismail/setup-kustomize@v2
+      uses: imranismail/setup-kustomize@v3
 
     - name: "Update Deployment Image Tag"
       shell: bash


### PR DESCRIPTION
## Context

Consumers of these composite actions emit three warnings on every docker build.
Two of them originate here, and the third (`actions/checkout`) is fixed
per-consumer — see BuoySoftware/BuoyBot#774.

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: ... aws-actions/amazon-ecr-login@v1,
aws-actions/configure-aws-credentials@v1, docker/setup-buildx-action@v2,
imranismail/setup-kustomize@v2

Your docker password is not masked. ... The default value of the 'mask-password'
input has changed from 'false' to 'true' in the v2 release.

The `set-output` command is deprecated and will be disabled soon.
```

#65 bumped the Node 20 actions across several composite actions but did not
touch `build-image`, so its four pins were left behind.

## Solution

| Action | From | To | Clears |
| --- | --- | --- | --- |
| `docker/setup-buildx-action` | v2 | v4 | Node 20 |
| `aws-actions/configure-aws-credentials` | v1 | v6 | Node 20 |
| `aws-actions/amazon-ecr-login` | v1 | v2 | Node 20 + unmasked docker password |
| `imranismail/setup-kustomize` | v2 | v3 | Node 20 + `set-output` |

All five pins now report `using: node24`.

The unmasked-password warning needs no new input: `mask-password` defaults to
`'true'` in ecr-login v2. Its caveat is that masking stops the password being
shared between jobs — not a problem here, as only `outputs.registry` is consumed
and the password output is never referenced.

`setup-kustomize` is bumped in **both** `deploy-image` and `deploy-image-v2`;
otherwise the `set-output` warning would simply relocate to the older action.

## Notable changes for us

**`configure-aws-credentials` spans five majors, but the risk is narrow.** v2,
v4, and v6 are pure runtime bumps (Node 16 / 20 / 24). Only v3 and v5 change
behavior, and both are inert for how `build-image` calls it:

- v3's changes (default session duration 6h -> 1h, retry knobs,
  `output-credentials`) all concern **assume-role** flows. This action passes
  static access keys with no `role-to-assume`, so no session is assumed.
- v5's breaking change is invalid **boolean** input handling. This action passes
  three string inputs and no booleans.

**One real behavior change worth flagging:** as of v3, the AWS account ID is no
longer masked in logs by default, so it will now appear in build logs for the
five consuming repos (BuoyBot, Wharf, BuoyRails, Infirmary,
anchor_view_components). Low severity, but a genuine change rather than a no-op.

**`setup-kustomize` v2 -> v3 is effectively free.** The input surface is
identical, including the `kustomize-version: '*'` default; the only change is
`node20` -> `node24`.

## Risks / notes

These actions are consumed via `@main` by five repos, so this merges into all of
them at once. `configure-aws-credentials` v1 -> v6 is the only bump where reading
changelogs cannot fully rule out an undocumented change in ECR auth behavior.

Suggested sequencing: merge this, then watch a single build in the
lowest-stakes consumer (`anchor_view_components`) before treating it as settled.

Out of scope: `install-playwright-browsers` pins `actions/cache@v4` while
`precompile-assets` and `setup-node` are on v5 — unrelated to these warnings.

## Test plan

Composite `action.yml` files are not covered by tests, and actionlint does not
lint composite actions (it reports them as workflows missing `jobs`/`on`), so
verification is static plus a post-merge observation:

- [x] All three files parse as valid YAML.
- [x] Every new pin resolves and reports `using: node24`.
- [x] `mask-password` confirmed to default to `'true'` in ecr-login v2, and no
      consumer references the password output.
- [x] `configure-aws-credentials` v6 still accepts `aws-access-key-id`,
      `aws-secret-access-key`, and `aws-region`.
- [ ] After merge, confirm one `anchor_view_components` docker build succeeds:
      ECR login works, the image is tagged with the expected short/long SHA, and
      the kustomize image edit plus ArgoCD manifest push still land.