### PR TITLE
fix: attach structure.sql without mutating the release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  shell-tests:
+    name: Shell tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run shell tests
+        run: |
+          shopt -s nullglob
+          tests=(*/test-*.sh)
+          if [ ${#tests[@]} -eq 0 ]; then
+            echo "::error::No test scripts found"
+            exit 1
+          fi
+          status=0
+          for test in "${tests[@]}"; do
+            echo "::group::$test"
+            bash "$test" || status=1
+            echo "::endgroup::"
+          done
+          exit $status
+        shell: bash

--- a/generate-structure-sql/action.yml
+++ b/generate-structure-sql/action.yml
@@ -113,26 +113,40 @@ runs:
         echo "✅ structure.sql generated successfully"
       shell: bash
 
-    - name: Determine release properties
-      if: ${{ inputs.upload_to_release == 'true' && startsWith(github.ref, 'refs/tags/') }}
-      id: release_props
-      run: |
-        TAG="${GITHUB_REF_NAME}"
-        if [[ "$TAG" == *"-rc."* ]]; then
-          echo "prerelease=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "prerelease=false" >> "$GITHUB_OUTPUT"
-        fi
-      shell: bash
-
     - name: Upload to GitHub Release
       if: ${{ inputs.upload_to_release == 'true' && startsWith(github.ref, 'refs/tags/') }}
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: ${{ github.ref_name }}
-        prerelease: ${{ steps.release_props.outputs.prerelease == 'true' }}
-        files: ${{ inputs.structure_sql_path }}
-        fail_on_unmatched_files: true
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        TAG="${GITHUB_REF_NAME}"
+
+        # Creating or patching an existing release fails with
+        # `already_exists` on `tag_name` and takes the asset with it, so only
+        # ever attach.
+        if ! gh release view "$TAG" > /dev/null 2>&1; then
+          echo "::error::No release for $TAG; expected the release to be cut first"
+          exit 1
+        fi
+
+        gh release upload "$TAG" "${{ inputs.structure_sql_path }}" --clobber
+
+        echo "✅ structure.sql attached to release $TAG"
+      shell: bash
+
+    - name: Verify release asset
+      if: ${{ inputs.upload_to_release == 'true' && startsWith(github.ref, 'refs/tags/') }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        ASSET="$(basename "${{ inputs.structure_sql_path }}")"
+        # A clean exit from the upload is not proof the asset landed.
+        if ! gh release view "${GITHUB_REF_NAME}" \
+          --json assets --jq '.assets[].name' | grep -qx "$ASSET"; then
+          echo "::error::$ASSET is not attached to release ${GITHUB_REF_NAME}"
+          exit 1
+        fi
+        echo "✅ verified $ASSET is attached to release ${GITHUB_REF_NAME}"
+      shell: bash
 
     - name: Upload as workflow artifact
       if: ${{ inputs.upload_as_artifact == 'true' }}

--- a/generate-structure-sql/test-upload-to-release.sh
+++ b/generate-structure-sql/test-upload-to-release.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# Tests the "Upload to GitHub Release" and "Verify release asset" steps in
+# action.yml.
+#
+# Losing the asset is silent and costly: when the release already exists, an
+# upload that also patches release properties is rejected with
+# `already_exists` on `tag_name`, and the asset does not survive the failed
+# call. Downstream tooling then reads an empty schema diff from a run that
+# otherwise looks green.
+#
+# The step bodies are extracted from action.yml rather than restated here, so
+# the test exercises the shipped logic instead of a copy that can drift. `gh`
+# is stubbed on PATH to record the commands each step would issue.
+#
+# Usage: ./generate-structure-sql/test-upload-to-release.sh
+
+set -uo pipefail
+
+ACTION="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/action.yml"
+FIXTURES=$(mktemp -d)
+trap 'rm -rf "$FIXTURES"' EXIT
+
+failures=0
+
+# Extract a step's `run:` body and substitute the input expressions the way the
+# Actions runner would. The awk range restarts on each `name:` line, so it lands
+# on the named step regardless of step order.
+extract_step() {
+  local step_name="$1" structure_sql_path="$2"
+  awk "/name: $step_name/,/shell: bash/" "$ACTION" \
+    | sed -n '/run: |/,/shell: bash/p' \
+    | sed '1d;$d' \
+    | sed 's/^        //' \
+    | sed -e "s|\${{ inputs.structure_sql_path }}|$structure_sql_path|g"
+}
+
+# Runs the real step with a stubbed `gh` and echoes the commands it invoked, one
+# per line. Records the step's exit code for `status_of`.
+run_step() {
+  local tag="$1" release_exists="$2" fixture="$3"
+  local step_name="${4:-Upload to GitHub Release}" attached_assets="${5:-}"
+  local step
+  step=$(extract_step "$step_name" "db/structure.sql")
+  rm -rf "$fixture"
+  mkdir -p "$fixture/db" "$fixture/bin"
+
+  if [ -z "$step" ]; then
+    # No `run:` body to extract -- the step is a `uses:` action, or was renamed.
+    echo 2 > "$fixture/status"
+    return
+  fi
+
+  echo "-- schema" > "$fixture/db/structure.sql"
+
+  # Stub `gh`: logs every invocation, reports whether the release exists so the
+  # step can branch on it, and answers the asset query the verify step makes.
+  cat > "$fixture/bin/gh" <<STUB
+#!/usr/bin/env bash
+echo "gh \$*" >> "$fixture/gh.log"
+if [ "\$1 \$2" == "release view" ]; then
+  if [ "$release_exists" != "true" ]; then exit 1; fi
+  # The verify step asks for attached asset names via --json assets.
+  case "\$*" in
+    *--json?assets*) printf '%s\n' $attached_assets ;;
+  esac
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$fixture/bin/gh"
+
+  (
+    cd "$fixture" || exit 2
+    # `shell: bash` runs the body with `-e`, so mirror that here.
+    PATH="$fixture/bin:$PATH" GITHUB_REF_NAME="$tag" GH_TOKEN="stub" \
+      bash -e -c "$step" >/dev/null 2>&1
+  )
+  # Callers capture stdout via command substitution, so the status has to travel
+  # through the filesystem rather than a variable the subshell would discard.
+  echo $? > "$fixture/status"
+  cat "$fixture/gh.log" 2>/dev/null
+}
+
+# Reads the status recorded by the most recent run_step against `fixture`.
+status_of() {
+  cat "$1/status" 2>/dev/null || echo 2
+}
+
+assert_uploads_idempotently() {
+  local description="$1" tag="$2" release_exists="$3"
+  local log
+  log=$(run_step "$tag" "$release_exists" "$FIXTURES/upload")
+
+  if [ "$(status_of "$FIXTURES/upload")" -ne 0 ]; then
+    printf '  FAIL %s (step exited %s)\n' "$description" "$(status_of "$FIXTURES/upload")"
+    failures=$((failures + 1))
+    return
+  fi
+
+  # The upload must be idempotent: --clobber replaces an asset of the same name
+  # left behind by an earlier run instead of colliding with it.
+  if ! grep -q -- "release upload $tag .*--clobber" <<< "$log"; then
+    # shellcheck disable=SC2016  # backticks are prose in the message, not a subshell
+    printf '  FAIL %s (no idempotent `release upload ... --clobber`)\n' "$description"
+    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  # The regression guard: mutating the release is what GitHub rejects.
+  if grep -qE "release (edit|create) " <<< "$log"; then
+    printf '  FAIL %s (mutates the release; already_exists risk)\n' "$description"
+    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  printf '  ok   %s\n' "$description"
+}
+
+# An auto-created release would carry empty notes and a guessed prerelease flag,
+# so a missing one must fail rather than be created.
+assert_fails_loudly_when_release_missing() {
+  local description="$1" tag="$2"
+  local log
+  log=$(run_step "$tag" false "$FIXTURES/upload")
+
+  if grep -qE "release (create|edit) " <<< "$log"; then
+    printf '  FAIL %s (created the release instead of failing)\n' "$description"
+    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  if grep -q "release upload " <<< "$log"; then
+    printf '  FAIL %s (attempted upload with no release present)\n' "$description"
+    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  if [ "$(status_of "$FIXTURES/upload")" -eq 0 ]; then
+    printf '  FAIL %s (succeeded with no release present)\n' "$description"
+    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  printf '  ok   %s\n' "$description"
+}
+
+echo "Upload to GitHub Release"
+
+# The release already exists, which is the only case that occurs in practice.
+assert_uploads_idempotently "existing release, RC tag"      "v37.0-rc.1" true
+assert_uploads_idempotently "existing release, final tag"   "v37.0"      true
+
+assert_fails_loudly_when_release_missing "missing release, RC tag"    "v38.0-rc.1"
+assert_fails_loudly_when_release_missing "missing release, final tag" "v38.0"
+
+assert_verify() {
+  local description="$1" expected="$2" attached_assets="$3"
+  run_step "v37.0-rc.1" true "$FIXTURES/verify" "Verify release asset" \
+    "$attached_assets" > /dev/null
+
+  local actual="pass"
+  [ "$(status_of "$FIXTURES/verify")" -ne 0 ] && actual="fail"
+
+  if [ "$actual" == "$expected" ]; then
+    printf '  ok   %s\n' "$description"
+  else
+    printf '  FAIL %s (expected the step to %s, it %sed)\n' \
+      "$description" "$expected" "$actual"
+    failures=$((failures + 1))
+  fi
+}
+
+echo
+echo "Verify release asset"
+
+assert_verify "passes when structure.sql is attached"     pass "structure.sql"
+assert_verify "passes among other assets"                 pass "checksums.txt structure.sql"
+# The original bug: the release exists but the asset never landed.
+assert_verify "fails when no assets are attached"         fail ""
+assert_verify "fails when only other assets are attached" fail "checksums.txt"
+# Guards against a substring match letting a near-miss name through.
+assert_verify "fails on a partial name match"             fail "structure.sql.gz"
+
+if [ "$failures" -gt 0 ]; then
+  printf '\n%d assertion(s) failed\n' "$failures"
+  exit 1
+fi
+
+echo
+echo "all assertions passed"


### PR DESCRIPTION
## Context

`generate-structure-sql` dumps `db/structure.sql` on every version tag and
attaches it to the GitHub Release, where downstream tooling reads it to produce a
schema diff. Three repos consume this action on `@main`.

## Problem

A recent tag run generated the dump correctly, then failed attaching it, so the
schema diff came out empty.

`softprops/action-gh-release` uploads the asset and then issues a finalize PATCH
against the release. Once the release already exists — release candidate tags get
cut, released, then re-pushed — GitHub rejects that call:

```
Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}
```

The action retried three times, aborted, and the asset did not survive. The
release was left with `assets=0`.

This was not a one-off. The same signature accounts for three failures across two
release series, and `assets=0` tracks exactly with the failing runs while
successful runs carry `assets=1`. Because release candidate tags get re-pushed, it
recurs on that cadence.

## Solution

Attach the asset with `gh release upload --clobber`, which makes no attempt to
mutate the release, so the rejected call is gone rather than avoided. `--clobber`
keeps re-runs idempotent when a tag is pushed again.

A missing release now fails loudly instead of being created. The release is
always cut before this workflow runs, so absence means a broken release process;
auto-creating one would publish empty notes and a guessed prerelease flag onto a
tag humans read. Dropping that path also removes the need to classify release
candidate versus final tags, which a tag like `v1.0-rc1` would have got wrong.

`Determine release properties` existed only to feed `prerelease:` into the
finalize call, and is now unused.

The new `Verify release asset` step asserts the asset is actually attached rather
than trusting the upload step's exit code — the original failure reported success
at the point the asset was already lost.

No caller changes: all three consumers already grant `contents: write` and pass
identical `upload_to_release` / `upload_as_artifact` expressions. The
`workflow_dispatch` path is untouched, since it sets `upload_as_artifact` rather
than `upload_to_release` and skips these steps.

`.github/workflows/test.yml` is this repo's first CI workflow. It is
byte-identical to the one in #72, so the two merge cleanly in either order.

## Test plan

- [x] `generate-structure-sql/test-upload-to-release.sh` — 9/9 assertions pass,
      covering existing-vs-missing release, release candidate vs final tags, and
      the verify step's attached / missing / partial-name-match cases
- [x] Mutation-tested the guards: reintroducing `release create`, `release edit`,
      dropping `--clobber`, gutting the verify assertion, and removing the
      release-exists guard each turn the suite red (5/5 caught)
- [x] All 16 `action.yml` + workflow files parse as YAML; shellcheck clean on the
      test script; `bash -n` clean on all 8 `run:` bodies
- [ ] Reviewer: real verification is a tag push (or a `workflow_dispatch` run
      against an existing release tag) that ends with `structure.sql` attached and
      a populated schema diff
- [ ] Reviewer: this action is consumed as `@main` by three repos, so merging
      takes effect everywhere immediately. The behavior change worth checking is
      the loud failure on a missing release — verified across four recent release
      tags that the release is always created before this workflow publishes to it
