### PR TITLE
fix: surface the real gh error when release lookup fails during "Generate structure.sql"

### DIFF
--- a/generate-structure-sql/action.yml
+++ b/generate-structure-sql/action.yml
@@ -123,8 +123,8 @@ runs:
         # Creating or patching an existing release fails with
         # `already_exists` on `tag_name` and takes the asset with it, so only
         # ever attach.
-        if ! gh release view "$TAG" > /dev/null 2>&1; then
-          echo "::error::No release for $TAG; expected the release to be cut first"
+        if ! VIEW_OUTPUT=$(gh release view "$TAG" 2>&1); then
+          echo "::error::Could not look up release $TAG (expected it to be cut first): $VIEW_OUTPUT"
           exit 1
         fi
 


### PR DESCRIPTION
The release-exists check swallowed gh release view's output, so any failure -- permission error, rate limit, network blip -- was reported as "no release" even when one existed, as happened debugging v37.0-rc.3 on Wharf where the release was confirmed present via the API but the job still failed this check.