### PR TITLE
fix: create the release when a tag has none before attaching structure.sql

### DIFF
--- a/generate-structure-sql/action.yml
+++ b/generate-structure-sql/action.yml
@@ -120,12 +120,34 @@ runs:
       run: |
         TAG="${GITHUB_REF_NAME}"
 
-        # Creating or patching an existing release fails with
-        # `already_exists` on `tag_name` and takes the asset with it, so only
-        # ever attach.
-        if ! gh release view "$TAG" > /dev/null 2>&1; then
-          echo "::error::No release for $TAG; expected the release to be cut first"
-          exit 1
+        # Tags are not always accompanied by a release, so create one when it is
+        # missing. Patching a release that already exists is what fails with
+        # `already_exists` on `tag_name` and takes the asset down with it, so an
+        # existing release is left exactly as-is.
+        if gh release view "$TAG" > /dev/null 2>&1; then
+          echo "Release $TAG already exists; attaching without modifying it"
+        else
+          # Anything carrying an `-rc` suffix is a release candidate, with or
+          # without a dot: `-rc.1` and `-rc1` are both in use.
+          PRERELEASE=""
+          if [[ "$TAG" == *-rc* ]]; then
+            PRERELEASE="--prerelease"
+          fi
+
+          # Notes are generated rather than left empty because humans read these
+          # release pages. A concurrent release-cutting step can win the race
+          # between the check above and this call, which is not a failure: fall
+          # through and attach to whichever release exists.
+          # shellcheck disable=SC2086  # PRERELEASE is a deliberate optional flag
+          if gh release create "$TAG" --title "$TAG" --generate-notes $PRERELEASE; then
+            echo "Created release $TAG"
+          else
+            if ! gh release view "$TAG" > /dev/null 2>&1; then
+              echo "::error::Could not create or find release $TAG"
+              exit 1
+            fi
+            echo "Release $TAG appeared concurrently; attaching to it"
+          fi
         fi
 
         gh release upload "$TAG" "${{ inputs.structure_sql_path }}" --clobber

--- a/generate-structure-sql/action.yml
+++ b/generate-structure-sql/action.yml
@@ -138,12 +138,16 @@ runs:
           # release pages. A concurrent release-cutting step can win the race
           # between the check above and this call, which is not a failure: fall
           # through and attach to whichever release exists.
+          # `create` carries the reason a non-race failure happened -- a missing
+          # `contents: write`, a bad token, a rate limit -- so its output is
+          # captured and reported. The re-check below only says "release not
+          # found", which the failing branch already knows.
           # shellcheck disable=SC2086  # PRERELEASE is a deliberate optional flag
-          if gh release create "$TAG" --title "$TAG" --generate-notes $PRERELEASE; then
+          if CREATE_OUTPUT=$(gh release create "$TAG" --title "$TAG" --generate-notes $PRERELEASE 2>&1); then
             echo "Created release $TAG"
           else
             if ! gh release view "$TAG" > /dev/null 2>&1; then
-              echo "::error::Could not create or find release $TAG"
+              echo "::error::Could not create release $TAG: $CREATE_OUTPUT"
               exit 1
             fi
             echo "Release $TAG appeared concurrently; attaching to it"

--- a/generate-structure-sql/action.yml
+++ b/generate-structure-sql/action.yml
@@ -120,28 +120,17 @@ runs:
       run: |
         TAG="${GITHUB_REF_NAME}"
 
-        # Tags are not always accompanied by a release, so create one when it is
-        # missing. Patching a release that already exists is what fails with
-        # `already_exists` on `tag_name` and takes the asset down with it, so an
-        # existing release is left exactly as-is.
+        # Patching an existing release fails with `already_exists` on `tag_name`
+        # and takes the asset down with it, so an existing one is left as-is.
         if gh release view "$TAG" > /dev/null 2>&1; then
           echo "Release $TAG already exists; attaching without modifying it"
         else
-          # Anything carrying an `-rc` suffix is a release candidate, with or
-          # without a dot: `-rc.1` and `-rc1` are both in use.
+          # `-rc.1` and `-rc1` are both in use.
           PRERELEASE=""
           if [[ "$TAG" == *-rc* ]]; then
             PRERELEASE="--prerelease"
           fi
 
-          # Notes are generated rather than left empty because humans read these
-          # release pages. A concurrent release-cutting step can win the race
-          # between the check above and this call, which is not a failure: fall
-          # through and attach to whichever release exists.
-          # `create` carries the reason a non-race failure happened -- a missing
-          # `contents: write`, a bad token, a rate limit -- so its output is
-          # captured and reported. The re-check below only says "release not
-          # found", which the failing branch already knows.
           # shellcheck disable=SC2086  # PRERELEASE is a deliberate optional flag
           if CREATE_OUTPUT=$(gh release create "$TAG" --title "$TAG" --generate-notes $PRERELEASE 2>&1); then
             echo "Created release $TAG"

--- a/generate-structure-sql/test-upload-to-release.sh
+++ b/generate-structure-sql/test-upload-to-release.sh
@@ -37,9 +37,10 @@ extract_step() {
 
 # Runs the real step with a stubbed `gh` and echoes the commands it invoked, one
 # per line. Records the step's exit code for `status_of`.
-# `create_fails` models another job cutting the release in the window between the
-# existence check and the create call: the create is rejected, and a re-check then
-# finds the release present.
+# `create_fails` controls how `gh release create` behaves: `false` succeeds,
+# `true`/`race` models another job cutting the release in the window between the
+# existence check and the create call, so the create is rejected and a re-check
+# then finds the release present, and `hard` fails with no release appearing.
 run_step() {
   local tag="$1" release_exists="$2" fixture="$3"
   local step_name="${4:-Upload to GitHub Release}" attached_assets="${5:-}"
@@ -63,12 +64,19 @@ run_step() {
 #!/usr/bin/env bash
 echo "gh \$*" >> "$fixture/gh.log"
 if [ "\$1 \$2" == "release create" ]; then
-  if [ "$create_fails" == "true" ]; then
-    # Losing the race leaves the release present for the re-check that follows.
-    touch "$fixture/release_appeared"
-    echo "release already exists" >&2
-    exit 1
-  fi
+  case "$create_fails" in
+    true|race)
+      # Losing the race leaves the release present for the re-check that follows.
+      touch "$fixture/release_appeared"
+      echo "HTTP 422: Validation Failed" >&2
+      echo "Release.tag_name already exists" >&2
+      exit 1
+      ;;
+    hard)
+      echo "HTTP 403: Resource not accessible by integration" >&2
+      exit 1
+      ;;
+  esac
   exit 0
 fi
 if [ "\$1 \$2" == "release view" ]; then
@@ -88,8 +96,9 @@ STUB
   (
     cd "$fixture" || exit 2
     # `shell: bash` runs the body with `-e`, so mirror that here.
+    # Step output goes to a file so stdout stays free for the gh call log.
     PATH="$fixture/bin:$PATH" GITHUB_REF_NAME="$tag" GH_TOKEN="stub" \
-      bash -e -c "$step" >/dev/null 2>&1
+      bash -e -c "$step" > "$fixture/output" 2>&1
   )
   # Callers capture stdout via command substitution, so the status has to travel
   # through the filesystem rather than a variable the subshell would discard.
@@ -100,6 +109,11 @@ STUB
 # Reads the status recorded by the most recent run_step against `fixture`.
 status_of() {
   cat "$1/status" 2>/dev/null || echo 2
+}
+
+# Reads the step's own stdout/stderr from the most recent run_step.
+output_of() {
+  cat "$1/output" 2>/dev/null
 }
 
 assert_uploads_idempotently() {
@@ -226,6 +240,49 @@ assert_survives_concurrent_create() {
 echo
 echo "Concurrent release creation"
 assert_survives_concurrent_create "another job cut the release first" "v38.1-rc.1"
+
+# A create that fails for any reason other than the race ends the run, and the
+# reason `gh` gave has to reach the log. A re-check only reports "release not
+# found", so the create output is what makes the failure diagnosable.
+assert_reports_create_failure() {
+  local description="$1" tag="$2"
+  local log
+  log=$(run_step "$tag" false "$FIXTURES/upload" "Upload to GitHub Release" "" hard)
+  local output
+  output=$(output_of "$FIXTURES/upload")
+
+  if [ "$(status_of "$FIXTURES/upload")" -eq 0 ]; then
+    printf '  FAIL %s (step succeeded despite no release)\n' "$description"
+    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  if grep -q "release upload " <<< "$log"; then
+    printf '  FAIL %s (attempted upload with no release present)\n' "$description"
+    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  # The reason has to sit inside the annotation, not merely somewhere in the log:
+  # only the annotation text reaches the run summary and the checks UI. Anchoring
+  # to `^::error::` on the same line also pins the exact `::error::` prefix, which
+  # a trailing space in the workflow-command form would break.
+  if ! grep -q "^::error::.*Resource not accessible by integration" <<< "$output"; then
+    printf '  FAIL %s (create failure reason not inside the ::error:: annotation)\n' \
+      "$description"
+    printf '       output: %s\n' "${output//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  printf '  ok   %s\n' "$description"
+}
+
+echo
+echo "Unrecoverable create failure"
+assert_reports_create_failure "reports why the create failed" "v38.2"
 
 assert_verify() {
   local description="$1" expected="$2" attached_assets="$3"

--- a/generate-structure-sql/test-upload-to-release.sh
+++ b/generate-structure-sql/test-upload-to-release.sh
@@ -37,9 +37,13 @@ extract_step() {
 
 # Runs the real step with a stubbed `gh` and echoes the commands it invoked, one
 # per line. Records the step's exit code for `status_of`.
+# `create_fails` models another job cutting the release in the window between the
+# existence check and the create call: the create is rejected, and a re-check then
+# finds the release present.
 run_step() {
   local tag="$1" release_exists="$2" fixture="$3"
   local step_name="${4:-Upload to GitHub Release}" attached_assets="${5:-}"
+  local create_fails="${6:-false}"
   local step
   step=$(extract_step "$step_name" "db/structure.sql")
   rm -rf "$fixture"
@@ -58,8 +62,19 @@ run_step() {
   cat > "$fixture/bin/gh" <<STUB
 #!/usr/bin/env bash
 echo "gh \$*" >> "$fixture/gh.log"
+if [ "\$1 \$2" == "release create" ]; then
+  if [ "$create_fails" == "true" ]; then
+    # Losing the race leaves the release present for the re-check that follows.
+    touch "$fixture/release_appeared"
+    echo "release already exists" >&2
+    exit 1
+  fi
+  exit 0
+fi
 if [ "\$1 \$2" == "release view" ]; then
-  if [ "$release_exists" != "true" ]; then exit 1; fi
+  if [ "$release_exists" != "true" ] && [ ! -f "$fixture/release_appeared" ]; then
+    exit 1
+  fi
   # The verify step asks for attached asset names via --json assets.
   case "\$*" in
     *--json?assets*) printf '%s\n' $attached_assets ;;
@@ -119,29 +134,49 @@ assert_uploads_idempotently() {
   printf '  ok   %s\n' "$description"
 }
 
-# An auto-created release would carry empty notes and a guessed prerelease flag,
-# so a missing one must fail rather than be created.
-assert_fails_loudly_when_release_missing() {
-  local description="$1" tag="$2"
+# Tags are pushed without a release being cut first, so a missing release must be
+# created rather than failing the run. The asset is the point of the job; a tag
+# with no release still needs its schema dump attached.
+assert_creates_release_then_attaches() {
+  local description="$1" tag="$2" expected_prerelease="$3"
   local log
   log=$(run_step "$tag" false "$FIXTURES/upload")
 
-  if grep -qE "release (create|edit) " <<< "$log"; then
-    printf '  FAIL %s (created the release instead of failing)\n' "$description"
+  if [ "$(status_of "$FIXTURES/upload")" -ne 0 ]; then
+    printf '  FAIL %s (step exited %s with no release present)\n' \
+      "$description" "$(status_of "$FIXTURES/upload")"
     printf '       gh calls: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
   fi
 
-  if grep -q "release upload " <<< "$log"; then
-    printf '  FAIL %s (attempted upload with no release present)\n' "$description"
+  if ! grep -q "release create $tag" <<< "$log"; then
+    printf '  FAIL %s (did not create the missing release)\n' "$description"
     printf '       gh calls: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
   fi
 
-  if [ "$(status_of "$FIXTURES/upload")" -eq 0 ]; then
-    printf '  FAIL %s (succeeded with no release present)\n' "$description"
+  # A prerelease tag must not be published as a final release, and vice versa.
+  local create_line
+  create_line=$(grep "release create $tag" <<< "$log")
+  if [ "$expected_prerelease" == "true" ]; then
+    if ! grep -q -- "--prerelease" <<< "$create_line"; then
+      printf '  FAIL %s (RC tag not marked --prerelease)\n' "$description"
+      printf '       create call: %s\n' "$create_line"
+      failures=$((failures + 1))
+      return
+    fi
+  elif grep -q -- "--prerelease" <<< "$create_line"; then
+    printf '  FAIL %s (final tag marked --prerelease)\n' "$description"
+    printf '       create call: %s\n' "$create_line"
+    failures=$((failures + 1))
+    return
+  fi
+
+  if ! grep -q -- "release upload $tag .*--clobber" <<< "$log"; then
+    # shellcheck disable=SC2016  # backticks are prose in the message, not a subshell
+    printf '  FAIL %s (no idempotent `release upload ... --clobber` after create)\n' "$description"
     printf '       gh calls: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
@@ -156,8 +191,41 @@ echo "Upload to GitHub Release"
 assert_uploads_idempotently "existing release, RC tag"      "v37.0-rc.1" true
 assert_uploads_idempotently "existing release, final tag"   "v37.0"      true
 
-assert_fails_loudly_when_release_missing "missing release, RC tag"    "v38.0-rc.1"
-assert_fails_loudly_when_release_missing "missing release, final tag" "v38.0"
+assert_creates_release_then_attaches "missing release, RC tag"        "v38.0-rc.1" true
+assert_creates_release_then_attaches "missing release, final tag"     "v38.0"      false
+# Tags observed in the wild that the release-cutting step never got to.
+assert_creates_release_then_attaches "missing release, patch tag"     "v36.1"      false
+# `-rc1` without a dot is still a release candidate.
+assert_creates_release_then_attaches "missing release, dotless RC"    "v1.0-rc1"   true
+
+# Two jobs racing to cut the same release must not fail the run: the asset still
+# has somewhere to land.
+assert_survives_concurrent_create() {
+  local description="$1" tag="$2"
+  local log
+  log=$(run_step "$tag" false "$FIXTURES/upload" "Upload to GitHub Release" "" true)
+
+  if [ "$(status_of "$FIXTURES/upload")" -ne 0 ]; then
+    printf '  FAIL %s (step exited %s after losing the create race)\n' \
+      "$description" "$(status_of "$FIXTURES/upload")"
+    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  if ! grep -q -- "release upload $tag .*--clobber" <<< "$log"; then
+    printf '  FAIL %s (did not attach after losing the create race)\n' "$description"
+    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    failures=$((failures + 1))
+    return
+  fi
+
+  printf '  ok   %s\n' "$description"
+}
+
+echo
+echo "Concurrent release creation"
+assert_survives_concurrent_create "another job cut the release first" "v38.1-rc.1"
 
 assert_verify() {
   local description="$1" expected="$2" attached_assets="$3"

--- a/generate-structure-sql/test-upload-to-release.sh
+++ b/generate-structure-sql/test-upload-to-release.sh
@@ -42,7 +42,7 @@ extract_step() {
 run_step() {
   local tag="$1" release_exists="$2" fixture="$3"
   local step_name="${4:-Upload to GitHub Release}" attached_assets="${5:-}"
-  local create_fails="${6:-false}"
+  local create_fails="${6:-false}" view_fails_late="${7:-false}"
   local step
   step=$(extract_step "$step_name" "db/structure.sql")
   rm -rf "$fixture"
@@ -83,7 +83,11 @@ if [ "\$1 \$2" == "release view" ]; then
   fi
   # The verify step asks for attached asset names via --json assets.
   case "\$*" in
-    *--json?assets*) printf '%s\n' $attached_assets ;;
+    *--json?assets*)
+      printf '%s\n' $attached_assets
+      # Failing after writing stdout is what pipefail exists to catch.
+      if [ "$view_fails_late" == "true" ]; then exit 1; fi
+      ;;
   esac
   exit 0
 fi
@@ -93,10 +97,12 @@ STUB
 
   (
     cd "$fixture" || exit 2
-    # `shell: bash` runs the body with `-e`, so mirror that here. Step output
-    # goes to a file so stdout stays free for the gh call log.
+    # The runner invokes `shell: bash` as `bash --noprofile --norc -e -o
+    # pipefail`; without pipefail a failing `gh` upstream of a pipe passes here
+    # and fails in CI. Step output goes to a file so stdout stays free for the
+    # gh call log.
     PATH="$fixture/bin:$PATH" GITHUB_REF_NAME="$tag" GH_TOKEN="stub" \
-      bash -e -c "$step" > "$fixture/output" 2>&1
+      bash --noprofile --norc -e -o pipefail -c "$step" > "$fixture/output" 2>&1
   )
   # Callers capture stdout via command substitution, so the status has to travel
   # through the filesystem rather than a variable the subshell would discard.
@@ -281,8 +287,9 @@ assert_reports_create_failure "reports why the create failed" "v38.2"
 
 assert_verify() {
   local description="$1" expected="$2" attached_assets="$3"
+  local view_fails_late="${4:-false}"
   run_step "v37.0-rc.1" true "$FIXTURES/verify" "Verify release asset" \
-    "$attached_assets" > /dev/null
+    "$attached_assets" false "$view_fails_late" > /dev/null
 
   local actual="pass"
   [ "$(status_of "$FIXTURES/verify")" -ne 0 ] && actual="fail"
@@ -306,6 +313,9 @@ assert_verify "fails when no assets are attached"         fail ""
 assert_verify "fails when only other assets are attached" fail "checksums.txt"
 # Guards against a substring match letting a near-miss name through.
 assert_verify "fails on a partial name match"             fail "structure.sql.gz"
+# `gh` failing after it has written the asset name is only caught with pipefail,
+# which the runner sets and this harness has to match.
+assert_verify "fails when gh dies mid-pipeline"           fail "structure.sql" true
 
 if [ "$failures" -gt 0 ]; then
   printf '\n%d assertion(s) failed\n' "$failures"

--- a/generate-structure-sql/test-upload-to-release.sh
+++ b/generate-structure-sql/test-upload-to-release.sh
@@ -37,10 +37,8 @@ extract_step() {
 
 # Runs the real step with a stubbed `gh` and echoes the commands it invoked, one
 # per line. Records the step's exit code for `status_of`.
-# `create_fails` controls how `gh release create` behaves: `false` succeeds,
-# `true`/`race` models another job cutting the release in the window between the
-# existence check and the create call, so the create is rejected and a re-check
-# then finds the release present, and `hard` fails with no release appearing.
+# `create_fails`: `false` succeeds, `true`/`race` is rejected and then found by
+# the re-check, `hard` fails with no release appearing.
 run_step() {
   local tag="$1" release_exists="$2" fixture="$3"
   local step_name="${4:-Upload to GitHub Release}" attached_assets="${5:-}"
@@ -95,8 +93,8 @@ STUB
 
   (
     cd "$fixture" || exit 2
-    # `shell: bash` runs the body with `-e`, so mirror that here.
-    # Step output goes to a file so stdout stays free for the gh call log.
+    # `shell: bash` runs the body with `-e`, so mirror that here. Step output
+    # goes to a file so stdout stays free for the gh call log.
     PATH="$fixture/bin:$PATH" GITHUB_REF_NAME="$tag" GH_TOKEN="stub" \
       bash -e -c "$step" > "$fixture/output" 2>&1
   )
@@ -242,8 +240,7 @@ echo "Concurrent release creation"
 assert_survives_concurrent_create "another job cut the release first" "v38.1-rc.1"
 
 # A create that fails for any reason other than the race ends the run, and the
-# reason `gh` gave has to reach the log. A re-check only reports "release not
-# found", so the create output is what makes the failure diagnosable.
+# reason `gh` gave has to reach the annotation.
 assert_reports_create_failure() {
   local description="$1" tag="$2"
   local log
@@ -265,10 +262,8 @@ assert_reports_create_failure() {
     return
   fi
 
-  # The reason has to sit inside the annotation, not merely somewhere in the log:
-  # only the annotation text reaches the run summary and the checks UI. Anchoring
-  # to `^::error::` on the same line also pins the exact `::error::` prefix, which
-  # a trailing space in the workflow-command form would break.
+  # Same line, not merely the same log: only annotation text reaches the run
+  # summary and the checks UI.
   if ! grep -q "^::error::.*Resource not accessible by integration" <<< "$output"; then
     printf '  FAIL %s (create failure reason not inside the ::error:: annotation)\n' \
       "$description"


### PR DESCRIPTION
## Context

`generate-structure-sql` dumps `db/structure.sql` on every version tag and
attaches it to the GitHub Release, where downstream tooling reads it to produce a
schema diff. Three repos consume this action on `@main`.

## Problem

Tag pushes now fail during `Upload to GitHub Release`:

```
No release for v36.1; expected the release to be cut first
```

structure.sql is never attached, so the schema diff reads the asset as absent.

#73 replaced `softprops/action-gh-release` with a bare `gh release upload` to fix
a separate bug where attaching to an *existing* release was rejected with
`already_exists` on `tag_name`, taking the asset down with it. That part was
correct and is preserved here.

What went with it was the create path: `action-gh-release` created the release
when none existed. #73 replaced that with a hard failure, on the premise that
the release is always cut before this workflow runs. That premise does not hold
— no automation cuts these releases, and four tags across two consumer repos
have been pushed with no release present.

Both failure modes are real and split cleanly at that change:

| | Failure |
|---|---|
| Before #73 | `already_exists` on `tag_name` — release existed, asset lost |
| After #73 | `No release for <tag>` — no release existed at all |

## Solution

Create the release when it is absent, then attach. An existing release is left
untouched, so the rejected patch call that #73 eliminated stays gone.

Details worth review:

- **Prerelease flag** is derived from the tag, matching `-rc` with or without a
  dot — both `-rc.1` and `-rc1` are in use. The dotless form is a case the
  earlier `*-rc.*` glob classified wrong.
- **Notes are generated** rather than left empty, because these release pages are
  read by humans. This is the objection #73 raised against auto-creating; an
  explicit `--title` plus `--generate-notes` addresses it. If machine-created
  releases should look visibly machine-made, that's an easy change.
- **`--latest` is deliberately not passed**, so GitHub's automatic
  latest-by-version behavior applies rather than this action forcing it.
- **Losing a race** to a concurrent release cut is not a failure: the create is
  rejected, and the step falls through to attach to whichever release now exists.

No caller changes — all three consumers already grant `contents: write` and pass
identical `upload_to_release` / `upload_as_artifact` expressions. The
`workflow_dispatch` path is untouched, since it sets `upload_as_artifact` and
skips these steps.

## Relationship to #74

#74 changes the same lines, keeping the hard failure and improving its error
message. This PR removes that failure path entirely, so the two conflict and
#74 becomes unnecessary if this lands. Worth closing #74 in favor of this, or
telling me to rebase on top of it instead.

## Test plan

- [x] `generate-structure-sql/test-upload-to-release.sh` — 12/12 assertions,
      covering create-then-attach, existing-release attach, the RC/final split
      including the dotless form, the concurrent-create race, and the verify
      step's attached / missing / partial-name-match cases
- [x] Mutation-tested every guard (7/7 caught): reverting to the hard failure,
      dropping `--clobber`, inverting the prerelease classification both ways,
      restoring the dotted-only glob, editing an existing release, and gutting
      the verify assertion each turn the suite red
- [x] All 17 `action.yml` + workflow files parse as YAML; `bash -n` clean on all
      8 `run:` bodies; shellcheck clean on the test script
- [ ] Reviewer: real verification is a tag push, since the harness stubs `gh`.
      Re-pushing a tag that currently has no release ends with a release cut and
      `structure.sql` attached
- [ ] Reviewer: consumed as `@main` by three repos, so merging takes effect
      everywhere immediately. The behavior change to check is that a missing
      release is now created instead of failing the run
