### PR TITLE
Attach structure.sql over the REST API, dropping the gh CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/generate-structure-sql/action.yml
+++ b/generate-structure-sql/action.yml
@@ -9,6 +9,9 @@ description: |
   - PostgreSQL service container
   - Bundler secret env vars as required by the Gemfile (private gem server tokens, etc.)
   - DB credential env vars (DB_USERNAME, DB_PASSWORD)
+  - python3 on PATH for the release steps, which talk to the REST API
+    directly. The gh CLI is deliberately not used: GitHub-hosted runners
+    preinstall it and self-hosted images do not necessarily carry it.
 
 inputs:
   artifact_name_suffix:
@@ -117,50 +120,16 @@ runs:
       if: ${{ inputs.upload_to_release == 'true' && startsWith(github.ref, 'refs/tags/') }}
       env:
         GH_TOKEN: ${{ github.token }}
-      run: |
-        TAG="${GITHUB_REF_NAME}"
-
-        # Patching an existing release fails with `already_exists` on `tag_name`
-        # and takes the asset down with it, so an existing one is left as-is.
-        if gh release view "$TAG" > /dev/null 2>&1; then
-          echo "Release $TAG already exists; attaching without modifying it"
-        else
-          # `-rc.1` and `-rc1` are both in use.
-          PRERELEASE=""
-          if [[ "$TAG" == *-rc* ]]; then
-            PRERELEASE="--prerelease"
-          fi
-
-          # shellcheck disable=SC2086  # PRERELEASE is a deliberate optional flag
-          if CREATE_OUTPUT=$(gh release create "$TAG" --title "$TAG" --generate-notes $PRERELEASE 2>&1); then
-            echo "Created release $TAG"
-          else
-            if ! gh release view "$TAG" > /dev/null 2>&1; then
-              echo "::error::Could not create release $TAG: $CREATE_OUTPUT"
-              exit 1
-            fi
-            echo "Release $TAG appeared concurrently; attaching to it"
-          fi
-        fi
-
-        gh release upload "$TAG" "${{ inputs.structure_sql_path }}" --clobber
-
-        echo "✅ structure.sql attached to release $TAG"
+        STRUCTURE_SQL_PATH: ${{ inputs.structure_sql_path }}
+      run: python3 "$GITHUB_ACTION_PATH/attach_structure_sql.py"
       shell: bash
 
     - name: Verify release asset
       if: ${{ inputs.upload_to_release == 'true' && startsWith(github.ref, 'refs/tags/') }}
       env:
         GH_TOKEN: ${{ github.token }}
-      run: |
-        ASSET="$(basename "${{ inputs.structure_sql_path }}")"
-        # A clean exit from the upload is not proof the asset landed.
-        if ! gh release view "${GITHUB_REF_NAME}" \
-          --json assets --jq '.assets[].name' | grep -qx "$ASSET"; then
-          echo "::error::$ASSET is not attached to release ${GITHUB_REF_NAME}"
-          exit 1
-        fi
-        echo "✅ verified $ASSET is attached to release ${GITHUB_REF_NAME}"
+        STRUCTURE_SQL_PATH: ${{ inputs.structure_sql_path }}
+      run: python3 "$GITHUB_ACTION_PATH/verify_release_asset.py"
       shell: bash
 
     - name: Upload as workflow artifact

--- a/generate-structure-sql/attach_structure_sql.py
+++ b/generate-structure-sql/attach_structure_sql.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Attach the generated structure.sql to the pushed tag's GitHub release.
+
+Reads the tag from GITHUB_REF_NAME and the file from STRUCTURE_SQL_PATH, and
+talks to the release REST API directly, so the step needs no CLI on the
+runner.
+
+An existing release is attached to without being modified: patching one with a
+call that names the tag fails with `already_exists`, and the asset does not
+survive the failed call. A missing release is created first -- tags are pushed
+without a release being cut, and the asset still needs somewhere to land.
+
+The upload replaces an asset of the same name left behind by an earlier run,
+so re-running the job is safe.
+"""
+
+import os
+import sys
+from http import HTTPStatus
+from pathlib import Path
+from typing import Any, NoReturn
+from urllib.parse import quote
+
+import github_api
+
+
+def fail(message: str) -> NoReturn:
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def release_for(repository: str, tag: str) -> dict | None:
+    status, release = github_api.request(
+        "GET", f"/repos/{repository}/releases/tags/{tag}"
+    )
+    if status == HTTPStatus.OK and isinstance(release, dict):
+        return release
+    return None
+
+
+def created_release(repository: str, tag: str) -> dict:
+    """The release for the tag, created now or found after losing the race."""
+    payload: dict[str, Any] = {
+        "tag_name": tag,
+        "name": tag,
+        "generate_release_notes": True,
+        # `-rc.1` and `-rc1` are both in use.
+        "prerelease": "-rc" in tag,
+    }
+    status, release = github_api.request(
+        "POST", f"/repos/{repository}/releases", payload
+    )
+    if status == HTTPStatus.CREATED and isinstance(release, dict):
+        print(f"Created release {tag}")
+        return release
+
+    # Another job may have cut the release between the lookup and the create.
+    # Its release is somewhere for the asset to land, which is the point.
+    raced = release_for(repository, tag)
+    if raced is not None:
+        print(f"Release {tag} appeared concurrently; attaching to it")
+        return raced
+
+    fail(f"Could not create release {tag}: {github_api.error_message(release)}")
+
+
+def attach(repository: str, release: dict, path: Path) -> None:
+    """Upload the file to the release, replacing a same-named earlier asset."""
+    name = path.name
+    for asset in release.get("assets", []):
+        if asset["name"] == name:
+            status, body = github_api.request(
+                "DELETE", f"/repos/{repository}/releases/assets/{asset['id']}"
+            )
+            if status != HTTPStatus.NO_CONTENT:
+                fail(
+                    f"Could not replace the existing {name} asset: "
+                    f"{github_api.error_message(body)}"
+                )
+
+    url = release["upload_url"].split("{")[0] + f"?name={quote(name)}"
+    status, body = github_api.upload(url, path.read_bytes())
+    if status != HTTPStatus.CREATED:
+        fail(f"Could not upload {name}: {github_api.error_message(body)}")
+
+
+def main() -> None:
+    tag = os.environ["GITHUB_REF_NAME"]
+    repository = os.environ["GITHUB_REPOSITORY"]
+    path = Path(os.environ["STRUCTURE_SQL_PATH"])
+
+    release = release_for(repository, tag)
+    if release is not None:
+        print(f"Release {tag} already exists; attaching without modifying it")
+    else:
+        release = created_release(repository, tag)
+
+    attach(repository, release, path)
+    print(f"structure.sql attached to release {tag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/generate-structure-sql/attach_structure_sql.py
+++ b/generate-structure-sql/attach_structure_sql.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python3
 """Attach the generated structure.sql to the pushed tag's GitHub release.
 
-Reads the tag from GITHUB_REF_NAME and the file from STRUCTURE_SQL_PATH, and
-talks to the release REST API directly, so the step needs no CLI on the
-runner.
-
-An existing release is attached to without being modified: patching one with a
-call that names the tag fails with `already_exists`, and the asset does not
-survive the failed call. A missing release is created first -- tags are pushed
-without a release being cut, and the asset still needs somewhere to land.
-
-The upload replaces an asset of the same name left behind by an earlier run,
-so re-running the job is safe.
+Reads the tag from GITHUB_REF_NAME and the file from STRUCTURE_SQL_PATH. An
+existing release is attached to without being modified; a missing one is
+created first. The upload replaces a same-named asset from an earlier run.
 """
 
 import os
@@ -55,7 +47,6 @@ def created_release(repository: str, tag: str) -> dict:
         return release
 
     # Another job may have cut the release between the lookup and the create.
-    # Its release is somewhere for the asset to land, which is the point.
     raced = release_for(repository, tag)
     if raced is not None:
         print(f"Release {tag} appeared concurrently; attaching to it")

--- a/generate-structure-sql/fake_github.py
+++ b/generate-structure-sql/fake_github.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""A stand-in GitHub API for the shell harness, serving one fixture directory.
+
+The harness points GITHUB_API_URL here, so the shipped step bodies run against
+real HTTP with nothing stubbed on PATH. Every request is appended to
+`requests.log` as `METHOD path body`, which is what the assertions read: not
+whether the step succeeded, but what it actually asked the API to do.
+
+The fixture directory configures the responses:
+  release_exists   `true` when the release lookup should find one
+  attached_assets  asset names on the existing release, one per line
+  create_result    `ok`, `race` (rejected, release then present) or `hard`
+  view_fails       `true` when reading the release should return a 500
+
+The release's upload_url points back at this server, as the real API's points
+at its upload host. Once listening, the chosen port is written to `port`.
+
+Usage: python3 generate-structure-sql/fake_github.py <fixture-dir>
+"""
+
+import json
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+FIXTURE = Path(sys.argv[1])
+
+
+def setting(name: str, fallback: str = "false") -> str:
+    path = FIXTURE / name
+    return path.read_text().strip() if path.exists() else fallback
+
+
+class Handler(BaseHTTPRequestHandler):
+    # Whether the release exists, flipped by a lost race so the re-check that
+    # follows finds the winner's release.
+    exists = False
+
+    def _reply(self, status: int, body: dict | list) -> None:
+        raw = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _log_request(self) -> str:
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else b""
+        printable = body.decode(errors="replace").replace("\n", "\\n")
+        with (FIXTURE / "requests.log").open("a") as log:
+            print(f"{self.command} {self.path} {printable}", file=log)
+        return printable
+
+    def _release(self) -> dict:
+        assert isinstance(self.server, HTTPServer)
+        port = self.server.server_port
+        assets = [
+            {"name": name, "id": index + 1}
+            for index, name in enumerate(setting("attached_assets", "").split())
+        ]
+        return {
+            "id": 1234,
+            "assets": assets,
+            "upload_url": f"http://127.0.0.1:{port}/uploads/releases/1234/assets{{?name,label}}",
+        }
+
+    def do_GET(self) -> None:
+        self._log_request()
+        url = urlparse(self.path)
+
+        if re.fullmatch(r"/repos/[^/]+/[^/]+/releases/tags/[^/]+", url.path):
+            if setting("view_fails") == "true":
+                self._reply(500, {"message": "Internal Server Error"})
+                return
+            if setting("release_exists") == "true" or Handler.exists:
+                self._reply(200, self._release())
+            else:
+                self._reply(404, {"message": "Not Found"})
+            return
+
+        self._reply(404, {"message": f"unexpected GET {url.path}"})
+
+    def do_POST(self) -> None:
+        self._log_request()
+        url = urlparse(self.path)
+
+        if url.path.startswith("/uploads/"):
+            self._reply(201, {"name": "uploaded"})
+            return
+
+        if re.fullmatch(r"/repos/[^/]+/[^/]+/releases", url.path):
+            result = setting("create_result", "ok")
+            if result == "race":
+                Handler.exists = True
+                self._reply(
+                    422,
+                    {
+                        "message": "Validation Failed",
+                        "errors": [
+                            {
+                                "resource": "Release",
+                                "code": "already_exists",
+                                "field": "tag_name",
+                            }
+                        ],
+                    },
+                )
+                return
+            if result == "hard":
+                self._reply(403, {"message": "Resource not accessible by integration"})
+                return
+            self._reply(201, self._release() | {"assets": []})
+            return
+
+        self._reply(404, {"message": f"unexpected POST {url.path}"})
+
+    def do_DELETE(self) -> None:
+        self._log_request()
+        raw = b""
+        self.send_response(204)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def main() -> None:
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    (FIXTURE / "port").write_text(str(server.server_port))
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/generate-structure-sql/fake_github.py
+++ b/generate-structure-sql/fake_github.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python3
 """A stand-in GitHub API for the shell harness, serving one fixture directory.
 
-The harness points GITHUB_API_URL here, so the shipped step bodies run against
-real HTTP with nothing stubbed on PATH. Every request is appended to
-`requests.log` as `METHOD path body`, which is what the assertions read: not
-whether the step succeeded, but what it actually asked the API to do.
-
-The fixture directory configures the responses:
+Every request is appended to `requests.log` as `METHOD path body`, which is
+what the harness assertions read. The fixture directory configures the
+responses:
   release_exists   `true` when the release lookup should find one
   attached_assets  asset names on the existing release, one per line
   create_result    `ok`, `race` (rejected, release then present) or `hard`
   view_fails       `true` when reading the release should return a 500
 
-The release's upload_url points back at this server, as the real API's points
-at its upload host. Once listening, the chosen port is written to `port`.
+The release's upload_url points back at this server. Once listening, the
+chosen port is written to `port`.
 
 Usage: python3 generate-structure-sql/fake_github.py <fixture-dir>
 """

--- a/generate-structure-sql/github_api.py
+++ b/generate-structure-sql/github_api.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python3
 """Requests against the GitHub REST API, using the standard library only.
 
-The API root comes from GITHUB_API_URL, which the runner sets on every job,
-so the same scripts work against GitHub Enterprise hosts -- and a test can
-point them at a local stand-in server.
-
-Responses are returned with their status rather than raised, because callers
-branch on specific statuses -- a 404 that means "create it", a 422 that means
-"lost the race" -- and only the caller knows which ones are errors.
+The API root comes from GITHUB_API_URL. Responses are returned with their
+status rather than raised; only the caller knows which statuses are errors.
 """
 
 import json
@@ -20,9 +15,7 @@ from typing import Any
 def request(method: str, path: str, payload: dict | None = None) -> tuple[int, Any]:
     """The response status and decoded JSON body for an API call.
 
-    Connection-level failures return status 0 with the reason under
-    "message", shaped like an API error body so callers report both kinds of
-    failure the same way.
+    Connection-level failures return status 0 with the reason under "message".
     """
     url = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/") + path
     body = None if payload is None else json.dumps(payload).encode()
@@ -47,8 +40,8 @@ def request(method: str, path: str, payload: dict | None = None) -> tuple[int, A
 def upload(url: str, data: bytes) -> tuple[int, Any]:
     """The response status and decoded body for a binary asset upload.
 
-    Takes the full URL because asset uploads go to the host the release's
-    upload_url names, not the API root the other calls share.
+    Takes the full URL: uploads go to the release's upload_url host, not the
+    API root.
     """
     call = urllib.request.Request(
         url,

--- a/generate-structure-sql/github_api.py
+++ b/generate-structure-sql/github_api.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Requests against the GitHub REST API, using the standard library only.
+
+The API root comes from GITHUB_API_URL, which the runner sets on every job,
+so the same scripts work against GitHub Enterprise hosts -- and a test can
+point them at a local stand-in server.
+
+Responses are returned with their status rather than raised, because callers
+branch on specific statuses -- a 404 that means "create it", a 422 that means
+"lost the race" -- and only the caller knows which ones are errors.
+"""
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def request(method: str, path: str, payload: dict | None = None) -> tuple[int, Any]:
+    """The response status and decoded JSON body for an API call.
+
+    Connection-level failures return status 0 with the reason under
+    "message", shaped like an API error body so callers report both kinds of
+    failure the same way.
+    """
+    url = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/") + path
+    body = None if payload is None else json.dumps(payload).encode()
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+
+    call = urllib.request.Request(url, data=body, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(call, timeout=30) as response:
+            return response.status, _decode(response.read())
+    except urllib.error.HTTPError as error:
+        return error.code, _decode(error.read())
+    except urllib.error.URLError as error:
+        return 0, {"message": str(error.reason)}
+
+
+def upload(url: str, data: bytes) -> tuple[int, Any]:
+    """The response status and decoded body for a binary asset upload.
+
+    Takes the full URL because asset uploads go to the host the release's
+    upload_url names, not the API root the other calls share.
+    """
+    call = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/octet-stream",
+        },
+    )
+    try:
+        with urllib.request.urlopen(call, timeout=120) as response:
+            return response.status, _decode(response.read())
+    except urllib.error.HTTPError as error:
+        return error.code, _decode(error.read())
+    except urllib.error.URLError as error:
+        return 0, {"message": str(error.reason)}
+
+
+def error_message(body: Any) -> str:
+    """The human-readable reason an API call failed."""
+    if isinstance(body, dict):
+        message = str(body.get("message", body))
+        codes = ", ".join(
+            str(error["code"])
+            for error in body.get("errors", [])
+            if isinstance(error, dict) and "code" in error
+        )
+        return f"{message} ({codes})" if codes else message
+    return str(body)
+
+
+def _decode(raw: bytes) -> Any:
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"message": raw.decode(errors="replace")}

--- a/generate-structure-sql/test-upload-to-release.sh
+++ b/generate-structure-sql/test-upload-to-release.sh
@@ -10,43 +10,53 @@
 # otherwise looks green.
 #
 # The step bodies are extracted from action.yml rather than restated here, so
-# the test exercises the shipped logic instead of a copy that can drift. `gh`
-# is stubbed on PATH to record the commands each step would issue.
+# the test exercises the shipped logic instead of a copy that can drift. The
+# steps run against a local stand-in GitHub API via GITHUB_API_URL, with
+# nothing stubbed on PATH; assertions read the requests the steps actually
+# made from the stand-in's log.
 #
 # Usage: ./generate-structure-sql/test-upload-to-release.sh
 
 set -uo pipefail
 
-ACTION="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/action.yml"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTION="$SCRIPT_DIR/action.yml"
 FIXTURES=$(mktemp -d)
 trap 'rm -rf "$FIXTURES"' EXIT
 
 failures=0
 
-# Extract a step's `run:` body and substitute the input expressions the way the
-# Actions runner would. The awk range restarts on each `name:` line, so it lands
-# on the named step regardless of step order.
+# Extract a step's `run:` body. The awk range restarts on each `name:` line, so
+# it lands on the named step regardless of step order. Steps take their values
+# from `env:`, so there are no `${{ }}` expressions left in the body to
+# substitute -- the harness sets the same variables the runner would.
+#
+# A step whose command is short enough to sit on the `run:` line itself is
+# extracted from there.
 extract_step() {
-  local step_name="$1" structure_sql_path="$2"
-  awk "/name: $step_name/,/shell: bash/" "$ACTION" \
-    | sed -n '/run: |/,/shell: bash/p' \
-    | sed '1d;$d' \
-    | sed 's/^        //' \
-    | sed -e "s|\${{ inputs.structure_sql_path }}|$structure_sql_path|g"
+  local step_name="$1" step
+  step=$(awk "/name: $step_name/,/shell: bash/" "$ACTION")
+
+  if grep -q 'run: |' <<< "$step"; then
+    sed -n '/run: |/,/shell: bash/p' <<< "$step" \
+      | sed '1d;$d' \
+      | sed 's/^        //'
+  else
+    sed -n 's/^      run: //p' <<< "$step"
+  fi
 }
 
-# Runs the real step with a stubbed `gh` and echoes the commands it invoked, one
-# per line. Records the step's exit code for `status_of`.
-# `create_fails`: `false` succeeds, `true`/`race` is rejected and then found by
-# the re-check, `hard` fails with no release appearing.
+# Runs a step against a fresh stand-in API serving the given fixture, and
+# echoes the requests the step made, one per line. Records the step's exit
+# code for `status_of` and its own output for `output_of`.
 run_step() {
   local tag="$1" release_exists="$2" fixture="$3"
   local step_name="${4:-Upload to GitHub Release}" attached_assets="${5:-}"
-  local create_fails="${6:-false}" view_fails_late="${7:-false}"
+  local create_result="${6:-ok}" view_fails="${7:-false}"
   local step
-  step=$(extract_step "$step_name" "db/structure.sql")
+  step=$(extract_step "$step_name")
   rm -rf "$fixture"
-  mkdir -p "$fixture/db" "$fixture/bin"
+  mkdir -p "$fixture/db"
 
   if [ -z "$step" ]; then
     # No `run:` body to extract -- the step is a `uses:` action, or was renamed.
@@ -55,59 +65,46 @@ run_step() {
   fi
 
   echo "-- schema" > "$fixture/db/structure.sql"
+  echo "$release_exists" > "$fixture/release_exists"
+  echo "$attached_assets" > "$fixture/attached_assets"
+  echo "$create_result" > "$fixture/create_result"
+  echo "$view_fails" > "$fixture/view_fails"
+  : > "$fixture/requests.log"
 
-  # Stub `gh`: logs every invocation, reports whether the release exists so the
-  # step can branch on it, and answers the asset query the verify step makes.
-  cat > "$fixture/bin/gh" <<STUB
-#!/usr/bin/env bash
-echo "gh \$*" >> "$fixture/gh.log"
-if [ "\$1 \$2" == "release create" ]; then
-  case "$create_fails" in
-    true|race)
-      # Losing the race leaves the release present for the re-check that follows.
-      touch "$fixture/release_appeared"
-      echo "HTTP 422: Validation Failed" >&2
-      echo "Release.tag_name already exists" >&2
-      exit 1
-      ;;
-    hard)
-      echo "HTTP 403: Resource not accessible by integration" >&2
-      exit 1
-      ;;
-  esac
-  exit 0
-fi
-if [ "\$1 \$2" == "release view" ]; then
-  if [ "$release_exists" != "true" ] && [ ! -f "$fixture/release_appeared" ]; then
-    exit 1
+  python3 "$SCRIPT_DIR/fake_github.py" "$fixture" &
+  local server_pid=$!
+  local waited=0
+  while [ ! -s "$fixture/port" ] && [ "$waited" -lt 100 ]; do
+    sleep 0.05
+    waited=$((waited + 1))
+  done
+  if [ ! -s "$fixture/port" ]; then
+    echo 3 > "$fixture/status"
+    kill "$server_pid" 2>/dev/null
+    return
   fi
-  # The verify step asks for attached asset names via --json assets.
-  case "\$*" in
-    *--json?assets*)
-      printf '%s\n' $attached_assets
-      # Failing after writing stdout is what pipefail exists to catch.
-      if [ "$view_fails_late" == "true" ]; then exit 1; fi
-      ;;
-  esac
-  exit 0
-fi
-exit 0
-STUB
-  chmod +x "$fixture/bin/gh"
 
   (
     cd "$fixture" || exit 2
     # The runner invokes `shell: bash` as `bash --noprofile --norc -e -o
-    # pipefail`; without pipefail a failing `gh` upstream of a pipe passes here
-    # and fails in CI. Step output goes to a file so stdout stays free for the
-    # gh call log.
-    PATH="$fixture/bin:$PATH" GITHUB_REF_NAME="$tag" GH_TOKEN="stub" \
-      bash --noprofile --norc -e -o pipefail -c "$step" > "$fixture/output" 2>&1
+    # pipefail`. Step output goes to a file so stdout stays free for the
+    # request log.
+    # GITHUB_ACTION_PATH is the action's own directory, so a step invoking a
+    # script there runs the shipped copy rather than one staged for the test.
+    env GITHUB_API_URL="http://127.0.0.1:$(cat "$fixture/port")" \
+      GITHUB_REF_NAME="$tag" GH_TOKEN="stub" \
+      GITHUB_ACTION_PATH="$SCRIPT_DIR" \
+      GITHUB_REPOSITORY="owner/repo" \
+      STRUCTURE_SQL_PATH="db/structure.sql" \
+      bash --noprofile --norc -e -o pipefail -c "$step" \
+      > "$fixture/output" 2>&1
   )
   # Callers capture stdout via command substitution, so the status has to travel
   # through the filesystem rather than a variable the subshell would discard.
   echo $? > "$fixture/status"
-  cat "$fixture/gh.log" 2>/dev/null
+  kill "$server_pid" 2>/dev/null
+  wait "$server_pid" 2>/dev/null
+  cat "$fixture/requests.log" 2>/dev/null
 }
 
 # Reads the status recorded by the most recent run_step against `fixture`.
@@ -121,30 +118,40 @@ output_of() {
 }
 
 assert_uploads_idempotently() {
-  local description="$1" tag="$2" release_exists="$3"
+  local description="$1" tag="$2" attached_assets="$3"
   local log
-  log=$(run_step "$tag" "$release_exists" "$FIXTURES/upload")
+  log=$(run_step "$tag" true "$FIXTURES/upload" "Upload to GitHub Release" \
+    "$attached_assets")
 
   if [ "$(status_of "$FIXTURES/upload")" -ne 0 ]; then
     printf '  FAIL %s (step exited %s)\n' "$description" "$(status_of "$FIXTURES/upload")"
+    printf '       output: %s\n' "$(output_of "$FIXTURES/upload" | tr '\n' '|')"
     failures=$((failures + 1))
     return
   fi
 
-  # The upload must be idempotent: --clobber replaces an asset of the same name
-  # left behind by an earlier run instead of colliding with it.
-  if ! grep -q -- "release upload $tag .*--clobber" <<< "$log"; then
-    # shellcheck disable=SC2016  # backticks are prose in the message, not a subshell
-    printf '  FAIL %s (no idempotent `release upload ... --clobber`)\n' "$description"
-    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+  if ! grep -q "^POST /uploads/releases/.*name=structure.sql" <<< "$log"; then
+    printf '  FAIL %s (did not upload the asset)\n' "$description"
+    printf '       requests: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
+  fi
+
+  # The upload must be idempotent: an asset of the same name left behind by an
+  # earlier run is replaced instead of collided with.
+  if grep -q "structure.sql" <<< "$attached_assets"; then
+    if ! grep -q "^DELETE /repos/owner/repo/releases/assets/" <<< "$log"; then
+      printf '  FAIL %s (did not replace the existing asset)\n' "$description"
+      printf '       requests: %s\n' "${log//$'\n'/ | }"
+      failures=$((failures + 1))
+      return
+    fi
   fi
 
   # The regression guard: mutating the release is what GitHub rejects.
-  if grep -qE "release (edit|create) " <<< "$log"; then
+  if grep -qE "^(POST /repos/owner/repo/releases |PATCH )" <<< "$log"; then
     printf '  FAIL %s (mutates the release; already_exists risk)\n' "$description"
-    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    printf '       requests: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
   fi
@@ -163,39 +170,31 @@ assert_creates_release_then_attaches() {
   if [ "$(status_of "$FIXTURES/upload")" -ne 0 ]; then
     printf '  FAIL %s (step exited %s with no release present)\n' \
       "$description" "$(status_of "$FIXTURES/upload")"
-    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    printf '       output: %s\n' "$(output_of "$FIXTURES/upload" | tr '\n' '|')"
     failures=$((failures + 1))
     return
   fi
 
-  if ! grep -q "release create $tag" <<< "$log"; then
+  local create_line
+  create_line=$(grep "^POST /repos/owner/repo/releases " <<< "$log")
+  if [ -z "$create_line" ]; then
     printf '  FAIL %s (did not create the missing release)\n' "$description"
-    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    printf '       requests: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
   fi
 
   # A prerelease tag must not be published as a final release, and vice versa.
-  local create_line
-  create_line=$(grep "release create $tag" <<< "$log")
-  if [ "$expected_prerelease" == "true" ]; then
-    if ! grep -q -- "--prerelease" <<< "$create_line"; then
-      printf '  FAIL %s (RC tag not marked --prerelease)\n' "$description"
-      printf '       create call: %s\n' "$create_line"
-      failures=$((failures + 1))
-      return
-    fi
-  elif grep -q -- "--prerelease" <<< "$create_line"; then
-    printf '  FAIL %s (final tag marked --prerelease)\n' "$description"
-    printf '       create call: %s\n' "$create_line"
+  if ! grep -q -- "\"prerelease\": $expected_prerelease" <<< "$create_line"; then
+    printf '  FAIL %s (expected prerelease=%s)\n' "$description" "$expected_prerelease"
+    printf '       create request: %s\n' "$create_line"
     failures=$((failures + 1))
     return
   fi
 
-  if ! grep -q -- "release upload $tag .*--clobber" <<< "$log"; then
-    # shellcheck disable=SC2016  # backticks are prose in the message, not a subshell
-    printf '  FAIL %s (no idempotent `release upload ... --clobber` after create)\n' "$description"
-    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+  if ! grep -q "^POST /uploads/releases/.*name=structure.sql" <<< "$log"; then
+    printf '  FAIL %s (did not attach after creating)\n' "$description"
+    printf '       requests: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
   fi
@@ -206,8 +205,10 @@ assert_creates_release_then_attaches() {
 echo "Upload to GitHub Release"
 
 # The release already exists, which is the only case that occurs in practice.
-assert_uploads_idempotently "existing release, RC tag"      "v37.0-rc.1" true
-assert_uploads_idempotently "existing release, final tag"   "v37.0"      true
+# A re-run finds its own earlier asset and must replace it.
+assert_uploads_idempotently "existing release, no asset yet"      "v37.0-rc.1" ""
+assert_uploads_idempotently "existing release, replaces its own"  "v37.0" "structure.sql"
+assert_uploads_idempotently "existing release, other assets"      "v37.0" "checksums.txt"
 
 assert_creates_release_then_attaches "missing release, RC tag"        "v38.0-rc.1" true
 assert_creates_release_then_attaches "missing release, final tag"     "v38.0"      false
@@ -221,19 +222,19 @@ assert_creates_release_then_attaches "missing release, dotless RC"    "v1.0-rc1"
 assert_survives_concurrent_create() {
   local description="$1" tag="$2"
   local log
-  log=$(run_step "$tag" false "$FIXTURES/upload" "Upload to GitHub Release" "" true)
+  log=$(run_step "$tag" false "$FIXTURES/upload" "Upload to GitHub Release" "" race)
 
   if [ "$(status_of "$FIXTURES/upload")" -ne 0 ]; then
     printf '  FAIL %s (step exited %s after losing the create race)\n' \
       "$description" "$(status_of "$FIXTURES/upload")"
-    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    printf '       output: %s\n' "$(output_of "$FIXTURES/upload" | tr '\n' '|')"
     failures=$((failures + 1))
     return
   fi
 
-  if ! grep -q -- "release upload $tag .*--clobber" <<< "$log"; then
+  if ! grep -q "^POST /uploads/releases/.*name=structure.sql" <<< "$log"; then
     printf '  FAIL %s (did not attach after losing the create race)\n' "$description"
-    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    printf '       requests: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
   fi
@@ -246,7 +247,7 @@ echo "Concurrent release creation"
 assert_survives_concurrent_create "another job cut the release first" "v38.1-rc.1"
 
 # A create that fails for any reason other than the race ends the run, and the
-# reason `gh` gave has to reach the annotation.
+# reason the API gave has to reach the annotation.
 assert_reports_create_failure() {
   local description="$1" tag="$2"
   local log
@@ -256,14 +257,14 @@ assert_reports_create_failure() {
 
   if [ "$(status_of "$FIXTURES/upload")" -eq 0 ]; then
     printf '  FAIL %s (step succeeded despite no release)\n' "$description"
-    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    printf '       requests: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
   fi
 
-  if grep -q "release upload " <<< "$log"; then
+  if grep -q "^POST /uploads/" <<< "$log"; then
     printf '  FAIL %s (attempted upload with no release present)\n' "$description"
-    printf '       gh calls: %s\n' "${log//$'\n'/ | }"
+    printf '       requests: %s\n' "${log//$'\n'/ | }"
     failures=$((failures + 1))
     return
   fi
@@ -287,9 +288,9 @@ assert_reports_create_failure "reports why the create failed" "v38.2"
 
 assert_verify() {
   local description="$1" expected="$2" attached_assets="$3"
-  local view_fails_late="${4:-false}"
+  local view_fails="${4:-false}"
   run_step "v37.0-rc.1" true "$FIXTURES/verify" "Verify release asset" \
-    "$attached_assets" false "$view_fails_late" > /dev/null
+    "$attached_assets" ok "$view_fails" > /dev/null
 
   local actual="pass"
   [ "$(status_of "$FIXTURES/verify")" -ne 0 ] && actual="fail"
@@ -299,6 +300,7 @@ assert_verify() {
   else
     printf '  FAIL %s (expected the step to %s, it %sed)\n' \
       "$description" "$expected" "$actual"
+    printf '       output: %s\n' "$(output_of "$FIXTURES/verify" | tr '\n' '|')"
     failures=$((failures + 1))
   fi
 }
@@ -313,9 +315,8 @@ assert_verify "fails when no assets are attached"         fail ""
 assert_verify "fails when only other assets are attached" fail "checksums.txt"
 # Guards against a substring match letting a near-miss name through.
 assert_verify "fails on a partial name match"             fail "structure.sql.gz"
-# `gh` failing after it has written the asset name is only caught with pipefail,
-# which the runner sets and this harness has to match.
-assert_verify "fails when gh dies mid-pipeline"           fail "structure.sql" true
+# A failed read is not a verified asset.
+assert_verify "fails when the release cannot be read"     fail "structure.sql" true
 
 if [ "$failures" -gt 0 ]; then
   printf '\n%d assertion(s) failed\n' "$failures"

--- a/generate-structure-sql/test-upload-to-release.sh
+++ b/generate-structure-sql/test-upload-to-release.sh
@@ -10,10 +10,9 @@
 # otherwise looks green.
 #
 # The step bodies are extracted from action.yml rather than restated here, so
-# the test exercises the shipped logic instead of a copy that can drift. The
-# steps run against a local stand-in GitHub API via GITHUB_API_URL, with
-# nothing stubbed on PATH; assertions read the requests the steps actually
-# made from the stand-in's log.
+# the test exercises the shipped logic instead of a copy that can drift. They
+# run against a local stand-in GitHub API, with assertions on the requests
+# they actually make. Nothing is stubbed on PATH.
 #
 # Usage: ./generate-structure-sql/test-upload-to-release.sh
 
@@ -89,8 +88,6 @@ run_step() {
     # The runner invokes `shell: bash` as `bash --noprofile --norc -e -o
     # pipefail`. Step output goes to a file so stdout stays free for the
     # request log.
-    # GITHUB_ACTION_PATH is the action's own directory, so a step invoking a
-    # script there runs the shipped copy rather than one staged for the test.
     env GITHUB_API_URL="http://127.0.0.1:$(cat "$fixture/port")" \
       GITHUB_REF_NAME="$tag" GH_TOKEN="stub" \
       GITHUB_ACTION_PATH="$SCRIPT_DIR" \

--- a/generate-structure-sql/verify_release_asset.py
+++ b/generate-structure-sql/verify_release_asset.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 """Verify the structure.sql asset is attached to the pushed tag's release.
 
-A clean exit from the upload is not proof the asset landed, and losing it is
-silent and costly: downstream tooling reads an empty schema diff from a run
-that otherwise looks green. The check asks the API for the release's assets
-and requires the exact file name -- a near-miss like `structure.sql.gz` does
-not count.
+A clean exit from the upload is not proof the asset landed. The check requires
+the exact file name, so a near-miss like `structure.sql.gz` does not count.
 """
 
 import os

--- a/generate-structure-sql/verify_release_asset.py
+++ b/generate-structure-sql/verify_release_asset.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Verify the structure.sql asset is attached to the pushed tag's release.
+
+A clean exit from the upload is not proof the asset landed, and losing it is
+silent and costly: downstream tooling reads an empty schema diff from a run
+that otherwise looks green. The check asks the API for the release's assets
+and requires the exact file name -- a near-miss like `structure.sql.gz` does
+not count.
+"""
+
+import os
+import sys
+from http import HTTPStatus
+from pathlib import Path
+from typing import NoReturn
+
+import github_api
+
+
+def fail(message: str) -> NoReturn:
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    tag = os.environ["GITHUB_REF_NAME"]
+    repository = os.environ["GITHUB_REPOSITORY"]
+    name = Path(os.environ["STRUCTURE_SQL_PATH"]).name
+
+    status, release = github_api.request(
+        "GET", f"/repos/{repository}/releases/tags/{tag}"
+    )
+    if status != HTTPStatus.OK or not isinstance(release, dict):
+        fail(
+            f"Could not read release {tag} to verify its assets: "
+            f"{github_api.error_message(release)}"
+        )
+
+    attached = [asset["name"] for asset in release.get("assets", [])]
+    if name not in attached:
+        fail(f"{name} is not attached to release {tag}")
+    print(f"verified {name} is attached to release {tag}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context

The release steps in `generate-structure-sql` were rewritten around the `gh` CLI in #73/#75. GitHub-hosted runners preinstall `gh`; self-hosted runner images do not necessarily carry it, and the runners these workflows actually use don't.

## Problem

Every tag push since #75 fails at the upload step with `gh: command not found` — including attaching to a release a human already created, since `gh release view` fails the same way. CI here stays green because the harness stubs `gh` on PATH and the jobs run on GitHub-hosted runners: nothing could notice the real binary missing.

## Solution

`gh` was only ever an HTTP client here. The exists-check, the create with its race handling, the clobbering upload and the asset verification are all plain REST calls, now made by committed stdlib-only Python scripts running on the interpreter the runner does carry. Behaviour is unchanged: an existing release is attached to without being modified, a missing one is created with the same prerelease rule, and the upload still replaces a same-named asset from an earlier run.

The harness no longer stubs anything on PATH: it serves a local stand-in GitHub API and points the shipped step bodies at it via `GITHUB_API_URL`, asserting on the requests they actually make — so "the binary exists" is no longer an untested assumption.

## Test plan

- [x] 15 harness assertions (was 14; the idempotent-upload case now also covers replacing an earlier run's own asset)
- [x] The suite passes inside the runner image itself, which has no `gh` — the failing configuration, now exercised directly
- [x] Existing-release path verified to make no `POST`/`PATCH` against the release — the `already_exists` asset-loss regression stays locked out
- [ ] Reviewer: the prerelease rule here is deliberately unchanged (`-rc` substring), matching what #75 shipped

No ticket link — public repo; tracked internally.
