### PR TITLE
Provide the packages token to the Yarn Berry install environment

### DIFF
--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -101,6 +101,11 @@ runs:
 
     - name: Install yarn dependencies (Yarn Berry)
       if: ${{ inputs.install-dependencies == 'true' && steps.detect-yarn-berry.outputs.is_berry == 'true' }}
+      env:
+        # Yarn Berry resolves ${GITHUB_PACKAGES_TOKEN} in .yarnrc.yml from the
+        # process environment and fails hard when it is unset. Fall back to a
+        # job-level value so an empty input does not mask one the caller set.
+        GITHUB_PACKAGES_TOKEN: ${{ inputs.github_packages_token || env.GITHUB_PACKAGES_TOKEN }}
       run: yarn install --immutable
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Context

`setup-node` installs JS dependencies for its caller. Yarn 1.x reads registry auth from the `.npmrc` this action writes. Yarn Berry ignores `.npmrc`; a Berry repo's `.yarnrc.yml` references the token as `${GITHUB_PACKAGES_TOKEN}`, which Berry resolves from the process environment and fails hard on when unset.

## Problem

Since #72 fixed Berry detection for callers that leave `working-directory` unset, those callers take the Berry install path, and `yarn install --immutable` runs without `GITHUB_PACKAGES_TOKEN` in its environment. Installs fail with `Usage Error: Environment variable not found (GITHUB_PACKAGES_TOKEN)`. The action already receives the token as the `github_packages_token` input, but only ever wrote it to `.npmrc` — Yarn 1's mechanism — so it never reached Berry. Workflows that happen to export the variable at the job level are unaffected, which is why the gap wasn't caught in #72.

## Solution

Set `GITHUB_PACKAGES_TOKEN` on the Berry install step from the `github_packages_token` input. When the input is empty, fall back to `env.GITHUB_PACKAGES_TOKEN`, so callers that already provide a job-level value keep working instead of having it masked by an empty string.

No ticket — fixes a regression surfaced by #72.

## Test plan

- [x] Repo suites green locally: ruff format/check, ty, all `*/test_*.py` and `*/test-*.sh`
- [ ] After merge: `workflow_dispatch` a Berry consumer's `structure-sql` workflow — the yarn install step must get past dependency install (it currently fails in under a minute with the env error)
- [ ] Reviewer: confirm the `||` fallback — an empty step-level `env` value would otherwise override a caller's job-level export